### PR TITLE
Show number of failed tests in job view

### DIFF
--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildView.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildView.java
@@ -85,6 +85,17 @@ public class BuildView implements BuildViewModel {
         return 100;
     }
 
+    @Override
+    public int failureCount() {
+        if (build instanceof AbstractBuild<?, ?>) {
+            AbstractBuild<?, ?> jenkinsBuild = (AbstractBuild<?, ?>) build;
+            if (jenkinsBuild.getTestResultAction() == null)
+                return 0;
+            return jenkinsBuild.getTestResultAction().getFailCount();
+        }
+        return 0;
+    }
+
     private boolean isTakingLongerThanUsual() {
         return elapsedTime().greaterThan(estimatedDuration());
     }

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildViewModel.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildViewModel.java
@@ -14,6 +14,7 @@ public interface BuildViewModel {
     public Duration duration();
     public Duration estimatedDuration();
     public int progress();
+    public int failureCount();
 
     public boolean hasPreviousBuild();
     public BuildViewModel previousBuild();

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
@@ -127,6 +127,11 @@ public class JobView {
         return lastCompletedBuild().reasonForClaim();
     }
 
+    @JsonProperty
+    public int failureCount() {
+        return lastCompletedBuild().failureCount();
+    }
+
     public String toString() {
         return name();
     }

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/NullBuildView.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/NullBuildView.java
@@ -48,6 +48,11 @@ public class NullBuildView implements BuildViewModel {
     }
 
     @Override
+    public int failureCount() {
+        return 0;
+    }
+
+    @Override
     public boolean hasPreviousBuild() {
         return false;
     }

--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-jobViews.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-jobViews.jelly
@@ -14,6 +14,7 @@
                        href="{{job.url}}">{{job.name}}</a>
                 </h2>
                 <ul class="description">
+                    <li data-ng-show="job.failureCount > 0"><strong>{{job.failureCount}}</strong> failed tests</li>
                     <li data-ng-show="job.claimed">Claimed by <strong>{{ job.claimAuthor }}</strong>: {{ job.claimReason }}</li>
                 </ul>
                 <ul data-ng-show="job.culprits.size() > 0" class="culprits">

--- a/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewTest.java
+++ b/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewTest.java
@@ -414,6 +414,7 @@ public class JobViewTest {
         assertThat(view.culprits(),          hasSize(0));
         assertThat(view.status(),            is("failing"));
         assertThat(view.isClaimed(), is(false));
+        assertThat(view.failureCount(),      is(0));
     }
 
     /*


### PR DESCRIPTION
We've been using a different plugin to display our build wall, since it also shows the number of failed tests -- a metric we find useful on the wall.  This change makes the necessary modifications to the build monitor plugin to allow it to show the number of failed tests, as shown in the screenshot below.

![image](https://f.cloud.github.com/assets/809128/1528897/94d56be4-4c1e-11e3-849e-4ffafc5e26ad.png)
