### PR TITLE
Build Failure Analyzer integration: show number of detected failures

### DIFF
--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-jobViews.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-jobViews.jelly
@@ -21,7 +21,7 @@
                     <li data-ng-repeat="name in job.culprits">{{name}}</li>
                 </ul>
                 <ul ng-if="job.hasKnownFailures" class="failures">
-                    <li data-ng-repeat="name in job.knownFailures">{{name}}</li>
+                    Identified problems ({{job.knownFailures.length}}): <li data-ng-repeat="name in job.knownFailures">{{name}}</li>
                 </ul>
             </div>
 

--- a/src/main/webapp/themes/industrial.css
+++ b/src/main/webapp/themes/industrial.css
@@ -258,10 +258,6 @@ h2 {
 .build-monitor .meta .failures li:after { content: ","; }
 .build-monitor .meta .failures li:last-child:after { content: ""; }
 
-.build-monitor .failing ul.failures li:first-child:before {
-    content: "Identified Problems: ";
-}
-
 
 /*
  *   Layout


### PR DESCRIPTION
The build monitor can show failures detected by the Build Failure
Analyzer plugin, with output like:
    Identified problems: foo, bar, baz

This commit adds the number of detected failures, as follows:
    Identified problems (3): foo, bar, baz

This commit is similar to pull request #28, but leverages the existing integration with the Build Failure Analyzer plugin, which supports recognition of JUnit test results since version 1.11.0.