### PR TITLE
issue #70: add setting to hide culprits

### DIFF
--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-jobViews.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-jobViews.jelly
@@ -17,7 +17,7 @@
                 <ul class="description">
                     <li data-ng-show="job.claimed">Claimed by <strong>{{ job.claimAuthor }}</strong>: {{ job.claimReason }}</li>
                 </ul>
-                <ul ng-if="job.shouldIndicateCulprits" class="culprits">
+                <ul ng-if="job.shouldIndicateCulprits &amp;&amp; settings.hideCulprits == 0" class="culprits">
                     <li data-ng-repeat="name in job.culprits">{{name}}</li>
                 </ul>
                 <ul ng-if="job.hasKnownFailures" class="failures">

--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
@@ -20,6 +20,13 @@
             <label for="settings-colour-blind" title="Colour blind-friendly colour scheme">Colour blind mode?</label>
         </li>
         <li>
+            <input data-ng-model="settings.hideCulprits"
+                   data-ng-false-value="0"
+                   data-ng-true-value="1"
+                   id="settings-hide-culprits" type="checkbox" />
+            <label for="settings-hide-culprits" title="Hide culprits on unstable/failed jobs">Hide culprits?</label>
+        </li>
+        <li>
             <a class="btn"
                href="configure"
                title="Configure the '${it.displayName}' view">Add/Remove Jobs</a>

--- a/src/main/webapp/scripts/settings.js
+++ b/src/main/webapp/scripts/settings.js
@@ -8,6 +8,7 @@ angular.
             $scope.settings.fontSize        = cookieJar.get('fontSize',        1);
             $scope.settings.numberOfColumns = cookieJar.get('numberOfColumns', 2);
             $scope.settings.colourBlind     = cookieJar.get('colourBlind',     0);
+            $scope.settings.hideCulprits    = cookieJar.get('hideCulprits',    0);
 
             angular.forEach($scope.settings, function(value, name) {
                 $scope.$watch('settings.' + name, function(currentValue) {


### PR DESCRIPTION
This commit adds a new setting to hide culprits on broken/unstable
builds. This is (among others) useful when a build often has a very
long list of culprits, which is not nicely displayed on a given screen.

Fixes issue #70.