### PR TITLE
Added an option to sort by Full Name

### DIFF
--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByFullName.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByFullName.java
@@ -1,0 +1,12 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
+
+import hudson.model.AbstractProject;
+
+import java.util.Comparator;
+
+public class ByFullName implements Comparator<AbstractProject> {
+    @Override
+    public int compare(AbstractProject a, AbstractProject b) {
+        return a.getFullName().compareToIgnoreCase(b.getFullName());
+    }
+}

--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -56,6 +56,7 @@
     <select name="order" class="setting-input">
       <f:option value="ByName" selected='${it.currentOrder()=="ByName"}'>${%Name}</f:option>
       <f:option value="ByDisplayName" selected="${it.currentOrder()=='ByDisplayName'}">${%Display name}</f:option>
+      <f:option value="ByFullName" selected="${it.currentOrder()=='ByFullName'}">${%Full name}</f:option>
     </select>
   </f:entry>
 


### PR DESCRIPTION
In projects where folders are used to organise pipelines or collections of jobs, it is convenient to have these jobs appear next to each other.  If we sort by name, this does not take the folder names into account, and separates these related jobs.  This is a small fix to include another option for ordering jobs which includes the folder names.  