### PR TITLE
Added ability to hide\show builds running by specific users or by timer

### DIFF
--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
@@ -74,6 +74,7 @@ public class BuildMonitorView extends ListView {
     @DataBoundConstructor
     public BuildMonitorView(String name) {
         super(name);
+        filteringSettings = new BuildsFilteringSettings();
     }
 
     @Extension
@@ -101,33 +102,21 @@ public class BuildMonitorView extends ListView {
             }
             return FormValidation.ok();
         }
-
-        /*public AutoCompletionCandidates doAutoCompleteUsernames(@QueryParameter String value) {
-            AutoCompletionCandidates candidates = new AutoCompletionCandidates();
-            String[] usersFromSettings = value.split(",");
-            String usersExceptLastAsString = value.replace(usersFromSettings[usersFromSettings.length - 1] + ",", "");
-            candidates.add(usersExceptLastAsString);
-            Collection<User> allSystemUsers = User.getAll();
-
-
-            for (User user : allSystemUsers)
-                if (user.getId().toLowerCase().startsWith(users[users.length - 1].toLowerCase().trim())) {
-                    for (String savedUser : users) {
-                        candidates.add(savedUser);
-                    }
-                    candidates.add(user.getId());
-                }
-            return candidates;
-        }*/
     }
 
     @Override
     protected void submit(StaplerRequest req) throws ServletException, IOException, FormException {
         super.submit(req);
 
+        if(filteringSettings == null) {
+            filteringSettings = new BuildsFilteringSettings();
+        }
+
         String usernamesParam = req.getParameter("usernames");
-        if (usernamesParam != null || usernamesParam.length() > 0) {
+        if (usernamesParam != null && usernamesParam.length() > 0) {
             filteringSettings.setUsernames(usernamesParam.split(","));
+        } else {
+            filteringSettings.setUsernames(new String[0]);
         }
 
         String showScheduledBuildsParameter = req.getParameter("showScheduledBuilds");

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
@@ -97,6 +97,7 @@ public class BuildMonitorView extends ListView {
     @Override
     protected void submit(StaplerRequest req) throws ServletException, IOException, FormException {
         super.submit(req);
+        username = req.getParameter("username");
 
         String requestedOrdering = req.getParameter("order");
 
@@ -117,7 +118,12 @@ public class BuildMonitorView extends ListView {
         return currentOrderOrDefault().getClass().getSimpleName();
     }
 
+    public String username() {
+        return username;
+    }
+
     private Comparator<AbstractProject> order = new ByName();
+    private String username = null;
 
     @SuppressWarnings("unchecked")
     private Comparator<AbstractProject> orderIn(String requestedOrdering) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
@@ -155,9 +161,8 @@ public class BuildMonitorView extends ListView {
         List<JobView> jobs = new ArrayList<JobView>();
 
         Collections.sort(projects, currentOrderOrDefault());
-
         for (AbstractProject project : projects) {
-            jobs.add(JobView.of(project, withAugmentationsIfTheyArePresent()));
+            jobs.add(JobView.of(project, withAugmentationsIfTheyArePresent(), username));
         }
 
         return jobs;

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildsFilteringSettings.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildsFilteringSettings.java
@@ -1,0 +1,52 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor;
+
+/**
+ * Created by okotovic on 25.12.2014.
+ */
+public class BuildsFilteringSettings {
+    private String[] usernames;
+    private boolean showScheduledBuilds;
+    private boolean showAnonymousBuilds;
+
+    public BuildsFilteringSettings(String[] usernames, boolean showScheduledBuilds, boolean showAnonymousBuilds) {
+        this.usernames = usernames;
+        this.showScheduledBuilds = showScheduledBuilds;
+        this.showAnonymousBuilds = showAnonymousBuilds;
+    }
+
+    public BuildsFilteringSettings(){
+        this.usernames  = new String[0];
+        this.showScheduledBuilds = true;
+        this.showAnonymousBuilds = true;
+    }
+
+    public boolean isDefaultSettings() {
+        return (this.usernames.length == 0 && this.showScheduledBuilds && this.showAnonymousBuilds);
+    }
+
+    public String[] getUsernames() {
+        return usernames;
+    }
+
+    public void setUsernames(String[] usernames) {
+        for (int i = 0; i < usernames.length; i++)
+            usernames[i] = usernames[i].trim();
+        this.usernames = usernames;
+    }
+
+    public boolean isShowScheduledBuilds() {
+        return showScheduledBuilds;
+    }
+
+    public void setShowScheduledBuilds(boolean showScheduledBuilds) {
+        this.showScheduledBuilds = showScheduledBuilds;
+    }
+
+    public boolean isShowAnonymousBuilds() {
+        return showAnonymousBuilds;
+    }
+
+    public void setShowAnonymousBuilds(boolean showAnonymousBuilds) {
+        this.showAnonymousBuilds = showAnonymousBuilds;
+    }
+}

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
@@ -2,9 +2,8 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel;
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade.RelativeLocation;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.BuildAugmentor;
-import hudson.model.Job;
-import hudson.model.Result;
-import hudson.model.Run;
+import hudson.model.*;
+import hudson.util.RunList;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 import java.util.*;
@@ -169,7 +168,22 @@ public class JobView {
     }
 
     private BuildViewModel lastBuild() {
-        return buildViewOf(job.getLastBuild());
+
+
+        return buildViewOf(GetLastSuitableBuild("okotovic"));
+    }
+
+    private Run<?,?> GetLastSuitableBuild(String user) {
+        RunList builds =  job.getBuilds();
+
+        for (Object build : builds) {
+            Run<?,?> run = (Run<?,?>)build;
+            String userId = run.getCause(Cause.UserIdCause.class).getUserId();
+            if(userId != null && userId.equals(user)) {
+                return run;
+            }
+        }
+        return null;
     }
 
     private BuildViewModel lastCompletedBuild() {
@@ -186,6 +200,6 @@ public class JobView {
             return new NullBuildView();
         }
 
-        return BuildView.of(job.getLastBuild(), augmentor, relative, systemTime);
+        return BuildView.of(GetLastSuitableBuild("okotovic"), augmentor, relative, systemTime);
     }
 }

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
@@ -1,5 +1,6 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel;
 
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildsFilteringSettings;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade.RelativeLocation;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.BuildAugmentor;
 import hudson.model.*;
@@ -26,26 +27,26 @@ public class JobView {
         put(FAILURE,   "failing");
         put(ABORTED,   "failing");  // if someone has aborted it then something is clearly not right, right? :)
     }};
-    private final String usernameForRunsFiltering;
+    private final BuildsFilteringSettings filteringSettings;
 
     public static JobView of(Job<?, ?> job) {
-        return new JobView(job, new BuildAugmentor(), RelativeLocation.of(job), new Date(), "");
+        return new JobView(job, new BuildAugmentor(), RelativeLocation.of(job), new Date(), new BuildsFilteringSettings());
     }
 
     public static JobView of(Job<?, ?> job, BuildAugmentor augmentor) {
-        return new JobView(job, augmentor, RelativeLocation.of(job), new Date(), "");
+        return new JobView(job, augmentor, RelativeLocation.of(job), new Date(), new BuildsFilteringSettings());
     }
 
     public static JobView of(Job<?, ?> job, RelativeLocation location) {
-        return new JobView(job, new BuildAugmentor(), location, new Date(), "");
+        return new JobView(job, new BuildAugmentor(), location, new Date(), new BuildsFilteringSettings());
     }
 
     public static JobView of(Job<?, ?> job, Date systemTime) {
-        return new JobView(job, new BuildAugmentor(), RelativeLocation.of(job), systemTime, "");
+        return new JobView(job, new BuildAugmentor(), RelativeLocation.of(job), systemTime, new BuildsFilteringSettings());
     }
 
-    public static JobView of(Job<?, ?> job, BuildAugmentor augmentor, String usernameForRunsFiltering) {
-        return new JobView(job, augmentor, RelativeLocation.of(job), new Date(), usernameForRunsFiltering);
+    public static JobView of(Job<?, ?> job, BuildAugmentor augmentor, BuildsFilteringSettings filteringSettings) {
+        return new JobView(job, augmentor, RelativeLocation.of(job), new Date(), filteringSettings);
     }
 
     @JsonProperty
@@ -166,40 +167,73 @@ public class JobView {
     }
 
 
-    private JobView(Job<?, ?> job, BuildAugmentor augmentor, RelativeLocation relative, Date systemTime, String usernameForRunsFiltering) {
+    private JobView(Job<?, ?> job, BuildAugmentor augmentor, RelativeLocation relative, Date systemTime, BuildsFilteringSettings filteringSettings) {
         this.job        = job;
         this.augmentor  = augmentor;
         this.systemTime = systemTime;
         this.relative   = relative;
-        this.usernameForRunsFiltering = usernameForRunsFiltering;
+        this.filteringSettings = filteringSettings;
     }
 
     private BuildViewModel lastBuild() {
-        return buildViewOf(GetLastSuitableBuild(usernameForRunsFiltering));
+        return buildViewOf(getLastSuitableBuild());
     }
 
-    private Run<?,?> GetLastSuitableBuild(String usernameForRunsFiltering) {
-        if (usernameForRunsFiltering == null || usernameForRunsFiltering.length() == 0) {
-            return job.getLastBuild();
+    private String[] getAcceptableUsersList() {
+        List<String>systemUsersIds = new ArrayList<String>();
+        for (User user:User.getAll()) {
+            systemUsersIds.add(user.getId());
         }
 
+        Set<String> systemUsersIdsSet = new HashSet<String>(systemUsersIds);
+        Set<String> specifiedUsers = new HashSet<String>(Arrays.asList(filteringSettings.getUsernames()));
+        systemUsersIdsSet.retainAll(specifiedUsers);
+        String[] result = systemUsersIdsSet.toArray(new String[systemUsersIdsSet.size()]);
+        return result;
+    }
+
+    private boolean isShowBuild(List<Cause> causes, BuildsFilteringSettings filteringSettings) {
+        String[] users = getAcceptableUsersList();
+        for (Cause cause : causes) {
+            if(cause instanceof Cause.UserIdCause) {
+                Cause.UserIdCause userIdCause = ((Cause.UserIdCause) cause);
+                String userId = userIdCause.getUserId();
+
+                if(!filteringSettings.isShowAnonymousBuilds()) {
+                    if(userId == null) {
+                        return false;
+                    }
+                }
+
+                if(userId != null && !Arrays.asList(users).contains(userId)) {
+                    return false;
+                }
+            }
+            if (cause instanceof TimerTrigger.TimerTriggerCause && !filteringSettings.isShowScheduledBuilds()) {
+                return false;
+            }
+            if(cause instanceof Cause.UpstreamCause) {
+                Cause.UpstreamCause upstreamCause = ((Cause.UpstreamCause) cause);
+                List<Cause> upstreamCauses = upstreamCause.getUpstreamCauses();
+                return isShowBuild(upstreamCauses, filteringSettings);
+            }
+        }
+        return true;
+    }
+
+    private Run<?,?> getLastSuitableBuild() {
+        if (filteringSettings.isDefaultSettings()) {
+            return job.getLastBuild();
+        }
         RunList builds =  job.getBuilds();
 
         for (Object build : builds) {
             Run<?,?> run = (Run<?,?>)build;
             List<Cause> causes = run.getCauses();
-            for (Cause cause:causes) {
-                if (cause.getClass() == TimerTrigger.TimerTriggerCause.class) {
-                    return run;
-                }
-
-                if (cause.getClass() == Cause.UserIdCause.class) {
-                    Cause.UserIdCause userIdCause = ((Cause.UserIdCause) cause);
-                    String userId = userIdCause.getUserId();
-                    if(userId != null && userId.equals(usernameForRunsFiltering)) {
-                        return run;
-                    }
-                }
+            if(isShowBuild(causes, filteringSettings)){
+                return run;
+            } else {
+                continue;
             }
         }
         return null;
@@ -219,6 +253,6 @@ public class JobView {
             return new NullBuildView();
         }
 
-        return BuildView.of(GetLastSuitableBuild(usernameForRunsFiltering), augmentor, relative, systemTime);
+        return BuildView.of(getLastSuitableBuild(), augmentor, relative, systemTime);
     }
 }

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
@@ -3,6 +3,7 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade.RelativeLocation;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.BuildAugmentor;
 import hudson.model.*;
+import hudson.triggers.TimerTrigger;
 import hudson.util.RunList;
 import org.codehaus.jackson.annotate.JsonProperty;
 
@@ -186,9 +187,19 @@ public class JobView {
 
         for (Object build : builds) {
             Run<?,?> run = (Run<?,?>)build;
-            String userId = run.getCause(Cause.UserIdCause.class).getUserId();
-            if(userId != null && userId.equals(usernameForRunsFiltering)) {
-                return run;
+            List<Cause> causes = run.getCauses();
+            for (Cause cause:causes) {
+                if (cause.getClass() == TimerTrigger.TimerTriggerCause.class) {
+                    return run;
+                }
+
+                if (cause.getClass() == Cause.UserIdCause.class) {
+                    Cause.UserIdCause userIdCause = ((Cause.UserIdCause) cause);
+                    String userId = userIdCause.getUserId();
+                    if(userId != null && userId.equals(usernameForRunsFiltering)) {
+                        return run;
+                    }
+                }
             }
         }
         return null;

--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -12,8 +12,8 @@
     </select>
   </f:entry>
 
-  <f:entry title="Username" field="username">
-    <f:textbox />
+  <f:entry title="${%Username}" >
+    <f:textbox name="username" field="username" value="${it.username()}"/>
   </f:entry>
 
   <f:entry title="${%Recurse in subfolders}" field="recurse">

--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -12,6 +12,10 @@
     </select>
   </f:entry>
 
+  <f:entry title="Username" field="username">
+    <f:textbox />
+  </f:entry>
+
   <f:entry title="${%Recurse in subfolders}" field="recurse">
     <f:checkbox id="recurse"/>
   </f:entry>

--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -11,9 +11,14 @@
       <f:option value="2" selected="${it.statusFilter==false}">${%Disabled jobs only}</f:option>
     </select>
   </f:entry>
-
+  <f:entry title="${%Show builds are being run by timer}">
+    <f:checkbox id="showScheduledBuilds" name="showScheduledBuilds" field="showScheduledBuilds" checked="${it.showScheduledBuilds}"/>
+  </f:entry>
+  <f:entry title="${%Show builds are being run by anonymous}">
+    <f:checkbox id="showAnonymousBuilds" name="showAnonymousBuilds" field="showAnonymousBuilds" checked="${it.showAnonymousBuilds}"/>
+  </f:entry>
   <f:entry title="${%Username}" >
-    <f:textbox name="username" field="username" value="${it.username()}"/>
+    <f:textbox name="usernames" field="usernames" value="${it.usernames}"/>
   </f:entry>
 
   <f:entry title="${%Recurse in subfolders}" field="recurse">


### PR DESCRIPTION
We have dedicated Jenkins server that runs build and executes tests on different configurations. Each configuration is Jenkins job. Besides that, quite often members of our team run these jobs (with parameters different from Nightly build) manually for own purposes. At the same time we are willing to see on the monitor only builds are being run in Nightly build, so I implemented additional functionality for filtration by users, builds running by timer and anonymous users.
 
![capture](https://cloud.githubusercontent.com/assets/2571567/5901405/5c007d8a-a583-11e4-9940-01317aaa5cff.PNG)

How we achieve our goals with my solution (Look at the screenshot)? We show builds running only by timer and by one special user that is used if we want to make build "green" and display it on the monitor. 

I suppose this can be helpful for others.

Thanks.
 