### PR TITLE
Show failure descrition rather than name from Build Failure Analyzer

### DIFF
--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/bfa/Analysed.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/bfa/Analysed.java
@@ -22,7 +22,7 @@ public class Analysed implements Analysis {
     public List<String> failures() {
         List<String> failures = new ArrayList<String>(action.getFoundFailureCauses().size());
         for (FoundFailureCause failure : action.getFoundFailureCauses()) {
-            failures.add(failure.getName());
+            failures.add(failure.getDescription());
         }
         return failures;
     }


### PR DESCRIPTION
Currently, Build Monitor shows name of the failure from the Build Failure Analyzer. IMHO showing description would be more useful, since it uses placeholders which can be used to pass a message with more detailed info to the monitor.