### PR TITLE
(fix) Acceptance tests wait for build completion before continuing

### DIFF
--- a/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor_acceptance/scenarios/Context.java
+++ b/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor_acceptance/scenarios/Context.java
@@ -27,7 +27,11 @@ public class Context {
         project.getBuildersList().addAll(builders);
 
         if (shouldExecute) {
-            project.scheduleBuild2(0);
+            try {
+                project.scheduleBuild2(0).get();
+            } catch (Exception e) {
+                throw new RuntimeException("Scheduled build did not complete as expected", e);
+            }
         }
 
         return this;


### PR DESCRIPTION
Relates to #167 and #168.

This makes sure that an acceptance test that triggers a build also waits for the build to finish before continuing the test execution.

Before, this could cause tests to fail if a view was loaded while a job was still building but the test expected it to be completed.