### PR TITLE
Support for multijob: phases as lanes and status for current build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,12 @@
             <version>1.26</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jenkins-multijob-plugin</artifactId>
+            <version>1.18</version>
+            <optional>true</optional>
+        </dependency>
         <!-- /Jenkins CI plugins supported by the Build Monitor -->
 
         <dependency>

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByPhase.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByPhase.java
@@ -1,0 +1,53 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
+
+import java.util.List;
+import hudson.model.AbstractProject;
+import hudson.model.Job;
+import hudson.model.Hudson;
+import hudson.model.DependencyGraph;
+import hudson.tasks.Builder;
+import com.tikal.jenkins.plugins.multijob.MultiJobProject;
+import com.tikal.jenkins.plugins.multijob.MultiJobBuilder;
+import com.tikal.jenkins.plugins.multijob.PhaseJobsConfig;
+
+import java.util.Comparator;
+
+public class ByPhase implements Comparator<Job<?, ?>> {
+    @Override
+    public int compare(Job<?, ?> a, Job<?,?> b) {
+        int aphase = this.phaseof(a);
+        int bphase = this.phaseof(b);
+        return aphase - bphase;
+    }
+
+    private int phaseof(Job<?, ?> job) {
+        AbstractProject project = (AbstractProject) job;
+        DependencyGraph depsgraph = Hudson.getInstance().getDependencyGraph();
+        MultiJobProject parent = null;
+        for (final AbstractProject<?, ?> p : depsgraph.getUpstream(project)) {
+            if (p instanceof MultiJobProject) {
+                parent = (MultiJobProject) p;
+                break;
+            }
+        }
+        if (parent != null) {
+            List<Builder> builders = parent.getBuilders();
+            if (builders != null) {
+                int phase = 1;
+                for (Builder builder : builders) {
+                    if (builder instanceof MultiJobBuilder) {
+                        MultiJobBuilder multiJobBuilder = (MultiJobBuilder) builder;
+                        List<PhaseJobsConfig> phaseJobs = multiJobBuilder.getPhaseJobs();
+                        for (PhaseJobsConfig phaseJob : phaseJobs) {
+                            if (phaseJob.getJobName().equals(project.getDisplayName())) {
+                                return phase;
+                            }
+                        }
+                        phase++;
+                    }
+                }
+            }
+        }
+        return 0;
+    }
+}

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildView.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildView.java
@@ -8,6 +8,7 @@ import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.duration.Durati
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.BuildAugmentor;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.bfa.Analysis;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.claim.Claim;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.multijob.Multijob;
 import hudson.model.AbstractBuild;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -25,21 +26,26 @@ public class BuildView implements BuildViewModel {
     private final Date systemTime;
     private final BuildAugmentor augmentor;
     private final Config config;
+    private final boolean current;
 
     public static BuildView of(Run<?, ?> build) {
-        return new BuildView(build, Config.defaultConfig(), new BuildAugmentor(), RelativeLocation.of(build.getParent()), new Date());
+        return new BuildView(build, Config.defaultConfig(), new BuildAugmentor(), RelativeLocation.of(build.getParent()), new Date(), true);
     }
 
     public static BuildView of(Run<?, ?> build, Config config) {
-        return new BuildView(build, config, new BuildAugmentor(), RelativeLocation.of(build.getParent()), new Date());
+        return new BuildView(build, config, new BuildAugmentor(), RelativeLocation.of(build.getParent()), new Date(), true);
     }
 
     public static BuildView of(Run<?, ?> build, Config config, BuildAugmentor augmentor, Date systemTime) {
-        return new BuildView(build, config, augmentor, RelativeLocation.of(build.getParent()), systemTime);
+        return new BuildView(build, config, augmentor, RelativeLocation.of(build.getParent()), systemTime, true);
     }
 
     public static BuildView of(Run<?, ?> build, Config config, BuildAugmentor augmentor, RelativeLocation parentJobLocation, Date systemTime) {
-        return new BuildView(build, config, augmentor, parentJobLocation, systemTime);
+        return new BuildView(build, config, augmentor, parentJobLocation, systemTime, true);
+    }
+
+    public static BuildView of(Run<?, ?> build, Config config, BuildAugmentor augmentor, RelativeLocation parentJobLocation, Date systemTime, boolean current) {
+        return new BuildView(build, config, augmentor, parentJobLocation, systemTime, current);
     }
 
 
@@ -55,6 +61,9 @@ public class BuildView implements BuildViewModel {
 
     @Override
     public Result result() {
+        if (! current) {
+            return Result.NOT_BUILT;
+        }
         return build.getResult();
     }
 
@@ -64,6 +73,9 @@ public class BuildView implements BuildViewModel {
     }
 
     private boolean isRunning(Run<?, ?> build) {
+        if (! current) {
+            return false;
+        }
         return (build.hasntStartedYet() || build.isBuilding() || build.isLogUpdated());
     }
 
@@ -118,7 +130,7 @@ public class BuildView implements BuildViewModel {
 
     @Override
     public BuildViewModel previousBuild() {
-        return new BuildView(build.getPreviousBuild(), config, augmentor, this.parentJobLocation, systemTime);
+        return new BuildView(build.getPreviousBuild(), config, augmentor, this.parentJobLocation, systemTime, true);
     }
 
     @Override
@@ -171,6 +183,25 @@ public class BuildView implements BuildViewModel {
         return augmentor.detailsOf(build, Analysis.class);
     }
 
+    @Override
+    public int phase() {
+        return multijob().phase();
+    }
+
+    @Override
+    public int jobsinphase() {
+        return multijob().jobsinphase();
+    }
+
+    @Override
+    public int numphases() {
+        return multijob().numphases();
+    }
+
+    private Multijob multijob() {
+        return augmentor.detailsOf(build, Multijob.class);
+    }
+
     public String toString() {
         return name();
     }
@@ -185,11 +216,12 @@ public class BuildView implements BuildViewModel {
     }
 
 
-    private BuildView(Run<?, ?> build, Config config, BuildAugmentor augmentor, RelativeLocation parentJobLocation, Date systemTime) {
+    private BuildView(Run<?, ?> build, Config config, BuildAugmentor augmentor, RelativeLocation parentJobLocation, Date systemTime, boolean current) {
         this.build = build;
         this.config = config;
         this.augmentor = augmentor;
         this.parentJobLocation = parentJobLocation;
         this.systemTime = systemTime;
+        this.current = current;
     }
 }

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildViewModel.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildViewModel.java
@@ -30,4 +30,8 @@ public interface BuildViewModel {
     boolean hasKnownFailures();
 
     List<String> knownFailures();
+
+    int phase();
+    int jobsinphase();
+    int numphases();
 }

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/NullBuildView.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/NullBuildView.java
@@ -93,4 +93,19 @@ public class NullBuildView implements BuildViewModel {
     public List<String> knownFailures() {
         return null;
     }
+
+    @Override
+    public int phase() {
+        return 0;
+    }
+
+    @Override
+    public int jobsinphase() {
+        return 1;
+    }
+
+    @Override
+    public int numphases() {
+        return 1;
+    }
 }

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/BuildAugmentor.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/BuildAugmentor.java
@@ -1,14 +1,21 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins;
 
+import hudson.model.Hudson;
+import hudson.model.AbstractProject;
+import hudson.model.DependencyGraph;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.bfa.Analysed;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.bfa.Analysis;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.bfa.NotAnalysed;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.claim.Claim;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.claim.Claimed;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.claim.NotClaimed;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.multijob.Multijob;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.multijob.InMultijob;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.multijob.NoMultijob;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
 import hudson.model.Run;
 import hudson.plugins.claim.ClaimBuildAction;
+import com.tikal.jenkins.plugins.multijob.MultiJobProject;
 import jenkins.model.Jenkins;
 
 import java.util.HashSet;
@@ -20,6 +27,7 @@ public class BuildAugmentor {
 
     public static String CLAIM_PLUGIN = "claim";
     public static String ANALYSER_PLUGIN = "build-failure-analyzer";
+    public static String MULTIJOB_PLUGIN = "jenkins-multijob-plugin";
 
     public static BuildAugmentor fromDetectedPlugins() {
         BuildAugmentor augmentor = new BuildAugmentor();
@@ -29,6 +37,9 @@ public class BuildAugmentor {
         }
         if (isInstalled(ANALYSER_PLUGIN)) {
             augmentor.support(Analysis.class);
+        }
+        if (isInstalled(MULTIJOB_PLUGIN)) {
+            augmentor.support(Multijob.class);
         }
         return augmentor;
     }
@@ -43,6 +54,8 @@ public class BuildAugmentor {
     public <T extends Augmentation> T detailsOf(Run<?, ?> build, Class<T> augmentation) {
         if (augmentation.isAssignableFrom(Claim.class)) {
             return (T) detailsOfClaim(build);
+        } else if (augmentation.isAssignableFrom(Multijob.class)) {
+            return (T) detailsOfMultijob(build);
         } else {
             assert augmentation.isAssignableFrom(Analysis.class) : "Unknown augmentation should never happen outside of development";
             return (T) detailsOfAnalysis(build);
@@ -74,6 +87,25 @@ public class BuildAugmentor {
             }
         }
         return new NotAnalysed();
+    }
+
+    private Multijob detailsOfMultijob(Run<?, ?> build) {
+        if (isSupported(Multijob.class)) {
+            AbstractProject<?, ?> project = ((AbstractProject) build.getParent());
+            DependencyGraph depsgraph = Hudson.getInstance().getDependencyGraph();
+            MultiJobProject parent = null;
+            for (final AbstractProject<?, ?> p : depsgraph.getUpstream(project)) {
+                if (p instanceof MultiJobProject) {
+                    parent = (MultiJobProject) p;
+                    break;
+                }
+            }
+
+            if (parent != null) {
+                return new InMultijob(project, parent);
+            }
+        }
+        return new NoMultijob();
     }
 
     public void support(Class<? extends Augmentation> typeOfAugmentation) {

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/multijob/InMultijob.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/multijob/InMultijob.java
@@ -1,0 +1,61 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.multijob;
+
+import java.util.List;
+import hudson.model.AbstractProject;
+import hudson.tasks.Builder;
+import com.tikal.jenkins.plugins.multijob.MultiJobProject;
+import com.tikal.jenkins.plugins.multijob.MultiJobBuilder;
+import com.tikal.jenkins.plugins.multijob.PhaseJobsConfig;
+
+public class InMultijob implements Multijob {
+    private final int _phase;
+    private final int _jobsinphase;
+    private final int _numphases;
+
+    public InMultijob(AbstractProject<?, ?> project, MultiJobProject parent) {
+        List<Builder> builders = parent.getBuilders();
+        if (builders != null) {
+            int _phase = 0;
+            int _jobsinphase = 0;
+            int numphases = 0;
+            for (Builder builder : builders) {
+                if (builder instanceof MultiJobBuilder) {
+                    numphases++;
+                    MultiJobBuilder multiJobBuilder = (MultiJobBuilder) builder;
+                    List<PhaseJobsConfig> phaseJobs = multiJobBuilder
+                        .getPhaseJobs();
+                    int phase = 1;
+                    for (PhaseJobsConfig phaseJob : phaseJobs) {
+                        if (phaseJob.getJobName().equals(project.getDisplayName())) {
+                            _phase = phase;
+                            _jobsinphase = phaseJobs.size();
+                        }
+                    }
+                    phase++;
+                }
+            }
+            this._phase = _phase;
+            this._jobsinphase = _jobsinphase;
+            this._numphases = numphases;
+        } else {
+            this._phase = 0;
+            this._jobsinphase = 1;
+            this._numphases = 1;
+        }
+    }
+
+    @Override
+    public int phase() {
+        return _phase;
+    }
+
+    @Override
+    public int jobsinphase() {
+        return _jobsinphase;
+    }
+
+    @Override
+    public int numphases() {
+        return _numphases;
+    }
+}

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/multijob/Multijob.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/multijob/Multijob.java
@@ -1,0 +1,9 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.multijob;
+
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.Augmentation;
+
+public interface Multijob extends Augmentation {
+    public int phase();
+    public int jobsinphase();
+    public int numphases();
+}

--- a/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/multijob/NoMultijob.java
+++ b/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/multijob/NoMultijob.java
@@ -1,0 +1,18 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.plugins.multijob;
+
+public class NoMultijob implements Multijob {
+    @Override
+    public int phase() {
+        return 0;
+    }
+
+    @Override
+    public int jobsinphase() {
+        return 1;
+    }
+
+    @Override
+    public int numphases() {
+        return 1;
+    }
+}

--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -62,6 +62,7 @@
       <f:option value="ByDisplayName" selected="${it.currentOrder()=='ByDisplayName'}">${%Display name}</f:option>
       <f:option value="ByFullName" selected="${it.currentOrder()=='ByFullName'}">${%Full name}</f:option>
       <f:option value="ByStatus" selected="${it.currentOrder()=='ByStatus'}">${%Status}</f:option>
+      <f:option value="ByPhase" selected="${it.currentOrder()=='ByPhase'}">${%Multijob phase}</f:option>
     </select>
   </f:entry>
 

--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-jobViews.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-jobViews.jelly
@@ -1,9 +1,9 @@
 <ul id="job-views"
     data-ng-class="{ 'colour-blind-mode': settings.colourBlind == 1 }"
     data-ng-style="{'font-size': settings.fontSize + 'em'}"
-    class="columns-{{ settings.numberOfColumns }}">
+        >
 
-    <li ng-repeat="job in jobs" class="{{job.status}}" id="{{ job.name | slugify }}">
+    <li ng-repeat="job in jobs" class="columns-{{ settings.multijobLanes == 1 ? job.jobsinphase : settings.numberOfColumns }} {{job.status}}" id="{{ job.name | slugify }}">
         <div class="progress" style="width: {{job.progress}}%">
             <span>{{job.progress}}%</span>
         </div>

--- a/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
+++ b/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
@@ -9,6 +9,13 @@
             <slider floor="0.3" ceiling="2" step="0.1" precision="1" data-ng-model="settings.fontSize"></slider>
         </li>
         <li>
+            <input data-ng-model="settings.multijobLanes"
+                   data-ng-false-value="0"
+                   data-ng-true-value="1"
+                   id="settings-multijobLanes" type="checkbox" />
+            <label for="settings-multijob-lanes" title="Use multijob phases as lanes">Multijob phases a lanes?</label>
+        </li>
+        <li ng-hide="settings.multijobLanes">
             <span class="slider-label">Columns</span>
             <slider floor="1" ceiling="8" step="1" precision="0" data-ng-model="settings.numberOfColumns"></slider>
         </li>

--- a/src/main/webapp/scripts/settings.js
+++ b/src/main/webapp/scripts/settings.js
@@ -6,6 +6,7 @@ angular.
             'use strict';
 
             $scope.settings.fontSize        = cookieJar.get('fontSize',        1);
+            $scope.settings.multijobLanes   = cookieJar.get('multijobLanes',   0);
             $scope.settings.numberOfColumns = cookieJar.get('numberOfColumns', 2);
             $scope.settings.colourBlind     = cookieJar.get('colourBlind',     0);
             $scope.settings.showCulprits    = cookieJar.get('showCulprits',    1);

--- a/src/main/webapp/themes/industrial.css
+++ b/src/main/webapp/themes/industrial.css
@@ -321,35 +321,35 @@ h2 {
 .build-monitor ul#job-views>li {
     margin: 4px;
 }
-.build-monitor ul#job-views.columns-1 li {
+.build-monitor ul#job-views>li.columns-1 {
     -webkit-flex: 1 99%;
     flex: 1 99%;
 }
-.build-monitor ul#job-views.columns-2 li {
+.build-monitor ul#job-views>li.columns-2 {
     -webkit-flex: 1 48%;
     flex: 1 48%;
 }
-.build-monitor ul#job-views.columns-3 li {
+.build-monitor ul#job-views>li.columns-3 {
     -webkit-flex: 1 32%;
     flex: 1 32%;
 }
-.build-monitor ul#job-views.columns-4 li {
+.build-monitor ul#job-views>li.columns-4 {
     -webkit-flex: 1 24%;
     flex: 1 24%;
 }
-.build-monitor ul#job-views.columns-5 li {
+.build-monitor ul#job-views>li.columns-5 {
     -webkit-flex: 1 19%;
     flex: 1 19%;
 }
-.build-monitor ul#job-views.columns-6 li {
+.build-monitor ul#job-views>li.columns-6 {
     -webkit-flex: 1 15.5%;
     flex: 1 15.5%;
 }
-.build-monitor ul#job-views.columns-7 li {
+.build-monitor ul#job-views>li.columns-7 {
     -webkit-flex: 1 13%;
     flex: 1 13%;
 }
-.build-monitor ul#job-views.columns-8 li {
+.build-monitor ul#job-views>li.columns-8 {
     -webkit-flex: 1 11.5%;
     flex: 1 11.5%;
 }


### PR DESCRIPTION
The multijob integration is working as follows:
- you should order the jobs by phase (new order plugin)
- when "multijobLanes" is selected in the settings, the "columns" slider disappears, and the jobs will then have a width of 100% / jobs in that phase for the parent multijob
- you should not mix jobs from different multijobs projects, as they will be mixed up in the view
- when a new multijob run starts, the view is smart enough to show only the job status for that multijob run (thanks @brantone for #98)

Functionally, this implementation looks exactly as I though it should.
I'm do not think it is good enough from a code perspective. I was not able to add any tests, and I think I might be adding an unwanted dependency in some points. Do you have any pointers on that?