### PR TITLE
Pipeline number grouping

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -17,20 +17,8 @@ public class Config {
         return getOrElse(order, new ByName());
     }
 
-    public boolean getGroup() {
-        return group;
-    }
-
     public void setOrder(Comparator<Job<?, ?>> order) {
         this.order = order;
-    }
-
-    public void setGroup(String state) {
-        if (state == null) {
-            group = false;
-        } else {
-            group = true;
-        }
     }
 
     @Override
@@ -59,5 +47,4 @@ public class Config {
     }
 
     private Comparator<Job<?, ?>> order;
-    private boolean group;
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -21,6 +21,17 @@ public class Config {
         this.order = order;
     }
 
+    public void setGroup(String groupByPipelineNumber) {
+        if (groupByPipelineNumber != null) {
+            group = true;
+        } else {
+            group = false;
+        }
+    }
+    public boolean getGroup() {
+        return group;
+    }
+
     @Override
     public String toString() {
         return Objects.toStringHelper(this)
@@ -47,4 +58,5 @@ public class Config {
     }
 
     private Comparator<Job<?, ?>> order;
+    private boolean group;
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -17,8 +17,20 @@ public class Config {
         return getOrElse(order, new ByName());
     }
 
+    public boolean getGroup() {
+        return group;
+    }
+
     public void setOrder(Comparator<Job<?, ?>> order) {
         this.order = order;
+    }
+
+    public void setGroup(String state) {
+        if (state == null) {
+            group = false;
+        } else {
+            group = true;
+        }
     }
 
     @Override
@@ -47,4 +59,5 @@ public class Config {
     }
 
     private Comparator<Job<?, ?>> order;
+    private boolean group;
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/pipelineGroup.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/pipelineGroup.java
@@ -14,9 +14,9 @@ public class pipelineGroup implements Comparator<AbstractProject<?, ?>> {
     @Override
     public int compare(AbstractProject<?, ?> a, AbstractProject<?, ?> b) {
         if (BuildUtil.pipelineBuildNumber(a.getLastBuild()) < BuildUtil.pipelineBuildNumber(b.getLastBuild())) {
-            return -1;
-        } else if (BuildUtil.pipelineBuildNumber(a.getLastBuild()) > BuildUtil.pipelineBuildNumber(b.getLastBuild())) {
             return 1;
+        } else if (BuildUtil.pipelineBuildNumber(a.getLastBuild()) > BuildUtil.pipelineBuildNumber(b.getLastBuild())) {
+            return -1;
         } else {
             return 0;
         }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/pipelineGroup.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/pipelineGroup.java
@@ -1,0 +1,65 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
+
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class pipelineGroup implements Comparator<AbstractProject<?, ?>> {
+    private static final Logger LOGGER = Logger.getLogger(pipelineGroup.class.getName());
+
+    @Override
+    public int compare(AbstractProject<?, ?> a, AbstractProject<?, ?> b) {
+        if (pipelineBuildNumber(a) < pipelineBuildNumber(b)) {
+            return -1;
+        } else if (pipelineBuildNumber(a) > pipelineBuildNumber(b)) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    private int pipelineBuildNumber(AbstractProject<?, ?> project) {
+        int buildNumber;
+
+        AbstractBuild<?, ?> currentBuild = project.getLastBuild();
+        List<AbstractProject> upstreamProjects = project.getUpstreamProjects();
+        if (upstreamProjects.isEmpty()) {
+            buildNumber = currentBuild.getNumber();
+        } else if (getUpstreamBuild(upstreamProjects.get(0), currentBuild) == null) {
+            buildNumber = currentBuild.getNumber();
+        } else {
+            buildNumber = pipelineBuildNumber(upstreamProjects.get(0));
+        }
+        LOGGER.info(String.valueOf(project.getName() + " : " + String.valueOf(buildNumber)));
+        return buildNumber;
+    }
+
+    //Modified version of getDownStreamBuild from class BuildUtil in plugin Build pipeline plugin
+    private AbstractBuild<?, ?> getUpstreamBuild(final AbstractProject<?, ?> upstreamProject, final AbstractBuild<?, ?> currentBuild) {
+        if ((upstreamProject != null) && (currentBuild != null)) {
+            @SuppressWarnings("unchecked")
+            final List<AbstractBuild<?, ?>> upstreamBuilds = (List<AbstractBuild<?, ?>>) upstreamProject.getBuilds();
+            for (final AbstractBuild<?, ?> innerBuild : upstreamBuilds) {
+                for (final CauseAction action : currentBuild.getActions(CauseAction.class)) {
+                    for (final Cause cause : action.getCauses()) {
+                        if (cause instanceof Cause.UpstreamCause) {
+                            final Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause) cause;
+                            if (upstreamCause.getUpstreamProject().equals(innerBuild.getProject().getFullName())
+                                    && (upstreamCause.getUpstreamBuild() == innerBuild.getNumber())) {
+                                return innerBuild;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/pipelineGroup.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/pipelineGroup.java
@@ -1,9 +1,7 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
 
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Cause;
-import hudson.model.CauseAction;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.util.BuildUtil;
+import hudson.model.*;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -12,54 +10,15 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 public class pipelineGroup implements Comparator<AbstractProject<?, ?>> {
-    private static final Logger LOGGER = Logger.getLogger(pipelineGroup.class.getName());
 
     @Override
     public int compare(AbstractProject<?, ?> a, AbstractProject<?, ?> b) {
-        if (pipelineBuildNumber(a) < pipelineBuildNumber(b)) {
+        if (BuildUtil.pipelineBuildNumber(a.getLastBuild()) < BuildUtil.pipelineBuildNumber(b.getLastBuild())) {
             return -1;
-        } else if (pipelineBuildNumber(a) > pipelineBuildNumber(b)) {
+        } else if (BuildUtil.pipelineBuildNumber(a.getLastBuild()) > BuildUtil.pipelineBuildNumber(b.getLastBuild())) {
             return 1;
         } else {
             return 0;
         }
-    }
-
-    private int pipelineBuildNumber(AbstractProject<?, ?> project) {
-        int buildNumber;
-
-        AbstractBuild<?, ?> currentBuild = project.getLastBuild();
-        List<AbstractProject> upstreamProjects = project.getUpstreamProjects();
-        if (upstreamProjects.isEmpty()) {
-            buildNumber = currentBuild.getNumber();
-        } else if (getUpstreamBuild(upstreamProjects.get(0), currentBuild) == null) {
-            buildNumber = currentBuild.getNumber();
-        } else {
-            buildNumber = pipelineBuildNumber(upstreamProjects.get(0));
-        }
-        LOGGER.info(String.valueOf(project.getName() + " : " + String.valueOf(buildNumber)));
-        return buildNumber;
-    }
-
-    //Modified version of getDownStreamBuild from class BuildUtil in plugin Build pipeline plugin
-    private AbstractBuild<?, ?> getUpstreamBuild(final AbstractProject<?, ?> upstreamProject, final AbstractBuild<?, ?> currentBuild) {
-        if ((upstreamProject != null) && (currentBuild != null)) {
-            @SuppressWarnings("unchecked")
-            final List<AbstractBuild<?, ?>> upstreamBuilds = (List<AbstractBuild<?, ?>>) upstreamProject.getBuilds();
-            for (final AbstractBuild<?, ?> innerBuild : upstreamBuilds) {
-                for (final CauseAction action : currentBuild.getActions(CauseAction.class)) {
-                    for (final Cause cause : action.getCauses()) {
-                        if (cause instanceof Cause.UpstreamCause) {
-                            final Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause) cause;
-                            if (upstreamCause.getUpstreamProject().equals(innerBuild.getProject().getFullName())
-                                    && (upstreamCause.getUpstreamBuild() == innerBuild.getNumber())) {
-                                return innerBuild;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return null;
     }
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/util/BuildUtil.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/util/BuildUtil.java
@@ -1,0 +1,47 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.util;
+
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+
+import java.util.List;
+
+
+public class BuildUtil {
+
+    public static int pipelineBuildNumber(AbstractBuild<?, ?> currentBuild) {
+        int buildNumber;
+
+        AbstractProject<?, ?> currentProject = currentBuild.getProject();
+        List<AbstractProject> upstreamProjects = currentProject.getUpstreamProjects();
+        if (upstreamProjects.isEmpty()) {
+            buildNumber = currentBuild.getNumber();
+        } else  {
+            buildNumber = pipelineBuildNumber(getUpstreamBuild(upstreamProjects.get(0), currentBuild));
+        }
+        return buildNumber;
+    }
+
+    //Modified version of getDownStreamBuild from class BuildUtil in plugin Build pipeline plugin
+    private static AbstractBuild<?, ?> getUpstreamBuild(final AbstractProject<?, ?> upstreamProject, final AbstractBuild<?, ?> currentBuild) {
+        if ((upstreamProject != null) && (currentBuild != null)) {
+            @SuppressWarnings("unchecked")
+            final List<AbstractBuild<?, ?>> upstreamBuilds = (List<AbstractBuild<?, ?>>) upstreamProject.getBuilds();
+            for (final AbstractBuild<?, ?> innerBuild : upstreamBuilds) {
+                for (final CauseAction action : currentBuild.getActions(CauseAction.class)) {
+                    for (final Cause cause : action.getCauses()) {
+                        if (cause instanceof Cause.UpstreamCause) {
+                            final Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause) cause;
+                            if (upstreamCause.getUpstreamProject().equals(innerBuild.getProject().getFullName())
+                                    && (upstreamCause.getUpstreamBuild() == innerBuild.getNumber())) {
+                                return innerBuild;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
@@ -29,17 +29,21 @@ public class JobView {
     private final BuildAugmentor augmentor;
     private final RelativeLocation relative;
     private final Config config;
+    private final int pipelineNumber;
+    private final boolean groupPipeline;
 
-    public static JobView of(Job<?, ?> job, Config config, BuildAugmentor augmentor) {
-        return new JobView(job, config, augmentor, RelativeLocation.of(job), new Date());
+    public static JobView of(Job<?, ?> job, Config config, BuildAugmentor augmentor, int pipelineNumber, boolean groupPipeline) {
+        return new JobView(job, config, augmentor, RelativeLocation.of(job), new Date(), pipelineNumber, groupPipeline);
     }
 
-    public JobView(Job<?, ?> job, Config config, BuildAugmentor augmentor, RelativeLocation relative, Date systemTime) {
+    public JobView(Job<?, ?> job, Config config, BuildAugmentor augmentor, RelativeLocation relative, Date systemTime, int pipelineNumber, boolean groupPipeline) {
         this.job        = job;
         this.config     = config;
         this.augmentor  = augmentor;
         this.relative   = relative;
         this.systemTime = systemTime;
+        this.pipelineNumber = pipelineNumber;
+        this.groupPipeline = groupPipeline;
     }
 
     @JsonProperty
@@ -184,6 +188,12 @@ public class JobView {
     public List<String> knownFailures() {
         return lastCompletedBuild().knownFailures();
     }
+
+    @JsonProperty
+    public int pipelineNumber() { return pipelineNumber; }
+
+    @JsonProperty
+    public boolean groupByPipelineNumber() { return groupPipeline; }
 
     // todo track by job.hashCode messes up the animation
     @JsonProperty @Override

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -57,7 +57,7 @@
   </f:entry>
 
   <f:entry title="${%Group by pipeline number}" field="groupByPipelineNumber">
-    <f:checkbox/>
+    <f:checkbox name="groupByPipelineNumber"/>
   </f:entry>
 
   <f:entry title="${%Ordered by}" help="help/view-config/order.html">

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -56,8 +56,8 @@
     <f:textbox name="title" value="${it.title}"/>
   </f:entry>
 
-  <f:entry title="${%Group pipelines}" field="group">
-    <f:checkbox name="group"/>
+  <f:entry title="${%Group by pipeline number}" field="groupByPipelineNumber">
+    <f:checkbox/>
   </f:entry>
 
   <f:entry title="${%Ordered by}" help="help/view-config/order.html">

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -56,7 +56,11 @@
     <f:textbox name="title" value="${it.title}"/>
   </f:entry>
 
-  <f:entry title="${%Ordered by}">
+  <f:entry title="${%Group pipelines}" field="group">
+    <f:checkbox name="group"/>
+  </f:entry>
+
+  <f:entry title="${%Ordered by}" help="help/view-config/order.html">
     <select name="order" class="setting-input">
       <f:option value="ByName" selected='${it.currentOrder()=="ByName"}'>${%Name}</f:option>
       <f:option value="ByDisplayName" selected="${it.currentOrder()=='ByDisplayName'}">${%Display name}</f:option>

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/widgets.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/widgets.jelly
@@ -5,18 +5,27 @@
     class="columns-{{ settings.numberOfColumns }}">
 
     <!-- todo: fix the CSS3 progress bar 'pulse' animations so that they work with 'track by project.hashCode' -->
-    <li ng-repeat="project in jobs"
+    <!-- <span ng-repeat="project in jobs"> -->
+    <!-- if new pipeline id and/or pipeline name print: -->
+    <!-- <li ng-if="{{project.groupPipeline}}" style="flex:1 1 99%;"><div style="background-color:#666666;text-align:center;" class="basic project widget">#{{ .pipelineId }}</div></li> -->
+
+    <li
+        ng-repeat="project in jobs"
         class="{{ project.status }} basic project widget"
         id="{{ project.name | slugify }}"
     >
+
         <div class="progress" style="width: {{project.progress}}%">
             <span class="value">{{project.progress}}%</span>
         </div>
 
         <header>
+
             <h2>
-                <a title="{{project.name}}" href="{{project.url}}">{{project.name}}</a>
+                <div ng-if="project.groupByPipelineNumber" style="border-radius:5px; float:left; padding-right:5px; padding-left:5px; background:#666666;">#{{project.pipelineNumber}}</div>
+                <div><a title="{{project.name}}" href="{{project.url}}">{{project.name}}</a></div>
             </h2>
+
             <ul class="details">
                 <li>{{ project.headline }}</li>
                 <li data-ng-show="!!project.claimed" class="claim-plugin">Claimed by <strong>{{ project.claimAuthor }}</strong>: {{ project.claimReason }}</li>

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/JobViewRecipe.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/JobViewRecipe.java
@@ -15,6 +15,8 @@ public class JobViewRecipe implements Supplier<JobView> {
     private BuildAugmentor augmentor = new BuildAugmentor();
     private RelativeLocation relative;
     private Date systemTime = new Date();
+    private int pipelineId = 1;
+    private boolean groupPipeline = false;
 
     public JobViewRecipe of(Job<?, ?> job) {
         this.job = job;
@@ -44,6 +46,6 @@ public class JobViewRecipe implements Supplier<JobView> {
 
     @Override
     public JobView get() {
-        return new JobView(job, config, augmentor, relative, systemTime);
+        return new JobView(job, config, augmentor, relative, systemTime, pipelineId, groupPipeline);
     }
 }


### PR DESCRIPTION
Added a way to group jobs together based on which version of the pipeline they're in, if any. If an upstream job failed, the downstream jobs will still be connected to the last successful version of the upstream job. This grouping then separates these different versions of the pipeline for a better overview of the pipeline. 