### PR TITLE
Don't cache index page. (probably fixes #166)

### DIFF
--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
@@ -1,6 +1,8 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:x="jelly:xml">
 
     <st:contentType value="text/html;charset=UTF-8"/>
+    <st:setHeader name="Expires" value="0" />
+    <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate" />
 
     <j:new var="h" className="hudson.Functions"/>
     ${h.initPageVariables(context)}


### PR DESCRIPTION
Otherwise a reverse proxy might cache the CSRF-Crumb.

I could test this on an internal network, it's a bit tricky to reproduce:

1. Jenkins needs to be behind a caching reverse proxy.
2. User 1 opens the build monitor, everything seems fine
3. User 2 opens the build monitor, gets an error, because nginx sends the cached copy with the crumb of another user.