### PR TITLE
Fixing squid: S1192 String literals should not be duplicated

### DIFF
--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/aether/ConsoleRepositoryListener.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/aether/ConsoleRepositoryListener.java
@@ -6,6 +6,7 @@ import org.eclipse.aether.RepositoryEvent;
 import java.io.PrintStream;
 
 public class ConsoleRepositoryListener extends AbstractRepositoryListener {
+    private static final String FROM= " from ";
 
     private PrintStream out;
 
@@ -43,15 +44,15 @@ public class ConsoleRepositoryListener extends AbstractRepositoryListener {
     }
 
     public void artifactResolved(RepositoryEvent event) {
-        out.println(">> Resolved artifact " + event.getArtifact() + " from " + event.getRepository());
+        out.println(">> Resolved artifact " + event.getArtifact() + FROM + event.getRepository());
     }
 
     public void artifactDownloading(RepositoryEvent event) {
-        out.println(">> Downloading artifact " + event.getArtifact() + " from " + event.getRepository());
+        out.println(">> Downloading artifact " + event.getArtifact() + FROM + event.getRepository());
     }
 
     public void artifactDownloaded(RepositoryEvent event) {
-        out.println(">> Downloaded artifact " + event.getArtifact() + " from " + event.getRepository());
+        out.println(">> Downloaded artifact " + event.getArtifact() + FROM + event.getRepository());
     }
 
     public void artifactResolving(RepositoryEvent event) {
@@ -79,11 +80,11 @@ public class ConsoleRepositoryListener extends AbstractRepositoryListener {
     }
 
     public void metadataResolved(RepositoryEvent event) {
-        out.println(">> Resolved metadata " + event.getMetadata() + " from " + event.getRepository());
+        out.println(">> Resolved metadata " + event.getMetadata() + FROM + event.getRepository());
     }
 
     public void metadataResolving(RepositoryEvent event) {
-        out.println(">> Resolving metadata " + event.getMetadata() + " from " + event.getRepository());
+        out.println(">> Resolving metadata " + event.getMetadata() + FROM + event.getRepository());
     }
 
 }

--- a/build-monitor-acceptance/src/test/java/features/ProjectStatusShouldBeEasyToDetermine.java
+++ b/build-monitor-acceptance/src/test/java/features/ProjectStatusShouldBeEasyToDetermine.java
@@ -24,7 +24,7 @@ import static net.serenitybdd.screenplay.GivenWhenThen.*;
 
 @RunWith(SerenityRunner.class)
 public class ProjectStatusShouldBeEasyToDetermine {
-
+    private static final String MY_APP = "My App";
     Actor anna = Actor.named("Anna");
 
     @Managed public WebDriver herBrowser;
@@ -41,12 +41,12 @@ public class ProjectStatusShouldBeEasyToDetermine {
 
         givenThat(anna).wasAbleTo(
                 Navigate.to(jenkins.url()),
-                HaveASuccessfulProjectCreated.called("My App")
+                HaveASuccessfulProjectCreated.called(MY_APP)
         );
 
         when(anna).attemptsTo(HaveABuildMonitorViewCreated.showingAllTheProjects());
 
-        then(anna).should(seeThat(ProjectWidget.of("My App").information(),
+        then(anna).should(seeThat(ProjectWidget.of(MY_APP).information(),
                 displaysProjectStatusAs(Successful)
         ));
     }
@@ -56,12 +56,12 @@ public class ProjectStatusShouldBeEasyToDetermine {
 
         givenThat(anna).wasAbleTo(
                 Navigate.to(jenkins.url()),
-                HaveAFailingProjectCreated.called("My App")
+                HaveAFailingProjectCreated.called(MY_APP)
         );
 
         when(anna).attemptsTo(HaveABuildMonitorViewCreated.showingAllTheProjects());
 
-        then(anna).should(seeThat(ProjectWidget.of("My App").information(),
+        then(anna).should(seeThat(ProjectWidget.of(MY_APP).information(),
                 displaysProjectStatusAs(Failing)
         ));
     }

--- a/build-monitor-acceptance/src/test/java/features/ShouldDescribeEachProject.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldDescribeEachProject.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.is;
 
 @RunWith(SerenityRunner.class)
 public class ShouldDescribeEachProject {
-
+    private static final String EXAMPLE_GITHUB_PROJECT = "Example Github Project";
 
     Actor dave = Actor.named("Dave");
 
@@ -47,16 +47,16 @@ public class ShouldDescribeEachProject {
     public void displaying_a_custom_build_description() throws Exception {
         givenThat(dave).wasAbleTo(
                 Navigate.to(jenkins.url()),
-                HaveAProjectCreated.called("Example Github Project").andConfiguredTo(
+                HaveAProjectCreated.called(EXAMPLE_GITHUB_PROJECT).andConfiguredTo(
                         ExecuteAShellScript.that(outputsGithubProjectLog()),
                         SetBuildDescription.to("Revision: \\1").basedOnLogLineMatching("Checking out Revision ([^\\s]{6})")
                 ),
-                ScheduleABuild.of("Example Github Project")
+                ScheduleABuild.of(EXAMPLE_GITHUB_PROJECT)
         );
 
         when(dave).attemptsTo(HaveABuildMonitorViewCreated.showingAllTheProjects());
 
-        then(dave).should(seeThat(ProjectWidget.of("Example Github Project").details(), is("Revision: 67f4b3")));
+        then(dave).should(seeThat(ProjectWidget.of(EXAMPLE_GITHUB_PROJECT).details(), is("Revision: 67f4b3")));
     }
 
     private ShellScript outputsGithubProjectLog() {

--- a/build-monitor-acceptance/src/test/java/features/ShouldTellWhatBrokeTheBuild.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldTellWhatBrokeTheBuild.java
@@ -31,6 +31,8 @@ import static org.hamcrest.Matchers.is;
 @RunWith(SerenityRunner.class)
 public class ShouldTellWhatBrokeTheBuild {
 
+    private static final String MY_APP = "My App";
+
     Actor dave = Actor.named("Dave");
 
     @Managed public WebDriver hisBrowser;
@@ -66,16 +68,16 @@ public class ShouldTellWhatBrokeTheBuild {
                                 describedAs("${1,2} of ${1,1} unit tests failed").
                                 matching(".*Total: (\\d+).*Failed: ([1-9]\\d*).*")
                 ),
-                HaveAProjectCreated.called("My App").andConfiguredTo(
+                HaveAProjectCreated.called(MY_APP).andConfiguredTo(
                         ExecuteAShellScript.that(hasXUnitFailures()),
                         ExecuteAShellScript.that(Finishes_With_Error)
                 ),
-                ScheduleABuild.of("My App")
+                ScheduleABuild.of(MY_APP)
         );
 
         when(dave).attemptsTo(HaveABuildMonitorViewCreated.showingAllTheProjects());
 
-        then(dave).should(seeThat(ProjectWidget.of("My App").details(),
+        then(dave).should(seeThat(ProjectWidget.of(MY_APP).details(),
                 is("Identified problem: 5 of 143 unit tests failed")
         ));
     }

--- a/build-monitor-acceptance/src/test/java/features/ShouldTellWhoIsFixingTheBrokenBuild.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldTellWhoIsFixingTheBrokenBuild.java
@@ -29,6 +29,8 @@ import static org.hamcrest.core.Is.is;
 @RunWith(SerenityRunner.class)
 public class ShouldTellWhoIsFixingTheBrokenBuild {
 
+    private static final String RESPONSIBILITY_DEVELOPED = "Responsibly Developed";
+
     JenkinsUser ben = JenkinsUser.named("Ben");
 
     @Managed public WebDriver hisBrowser;
@@ -48,16 +50,16 @@ public class ShouldTellWhoIsFixingTheBrokenBuild {
         givenThat(ben).wasAbleTo(
                 Navigate.to(jenkins.url()),
                 LogIn.as(ben),
-                HaveAFailingClaimableProjectCreated.called("Responsibly Developed")
+                HaveAFailingClaimableProjectCreated.called(RESPONSIBILITY_DEVELOPED)
         );
 
         when(ben).attemptsTo(
                 HaveABuildMonitorViewCreated.showingAllTheProjects(),
-                Claim.lastBrokenBuildOf("Responsibly Developed").saying("My bad, fixing now"),
+                Claim.lastBrokenBuildOf(RESPONSIBILITY_DEVELOPED).saying("My bad, fixing now"),
                 GoBack.to("Build Monitor")
         );
 
-        then(ben).should(seeThat(ProjectWidget.of("Responsibly Developed").information(), displaysProjectStatusAs(Claimed)));
-        then(ben).should(seeThat(ProjectWidget.of("Responsibly Developed").details(),     is("Claimed by Ben: My bad, fixing now")));
+        then(ben).should(seeThat(ProjectWidget.of(RESPONSIBILITY_DEVELOPED).information(), displaysProjectStatusAs(Claimed)));
+        then(ben).should(seeThat(ProjectWidget.of(RESPONSIBILITY_DEVELOPED).details(),     is("Claimed by Ben: My bad, fixing now")));
     }
 }

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugin/assetbundler/PathToAssetTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugin/assetbundler/PathToAssetTest.java
@@ -11,12 +11,12 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 public class PathToAssetTest {
-
+    private static final String INDEX_LESS_PATH = "less/index.less";
     @Test
     public void combines_base_resource_url_given_by_jenkins_and_a_path_to_the_asset() throws Exception {
         URL base = baseResourceUrlGivenByJenkins("file:///opt/jenkins/plugins/build-monitor-plugin/");
 
-        PathToAsset path = new PathToAsset(base, "less/index.less");
+        PathToAsset path = new PathToAsset(base, INDEX_LESS_PATH);
 
         assertThat(absolute(path), is("/opt/jenkins/plugins/build-monitor-plugin/less/index.less"));
     }
@@ -25,7 +25,7 @@ public class PathToAssetTest {
     public void works_with_unc_paths_on_windows() throws Exception {
         URL base = baseResourceUrlGivenByJenkins("file://server/jenkins/plugins/build-monitor-plugin/");
 
-        PathToAsset path = new PathToAsset(base, "less/index.less");
+        PathToAsset path = new PathToAsset(base, INDEX_LESS_PATH);
 
         assertThat(absolute(path), is("/server/jenkins/plugins/build-monitor-plugin/less/index.less"));
     }
@@ -37,7 +37,7 @@ public class PathToAssetTest {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Sorry, can't load the asset from 'http://google.com/less/index.less' using the 'file' protocol");
 
-        new PathToAsset(new URL("http://google.com"), "less/index.less");
+        new PathToAsset(new URL("http://google.com"), INDEX_LESS_PATH);
     }
 
     // --

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewTest.java
@@ -28,6 +28,9 @@ public class JobViewTest {
 
     private static final String theName = "some-TLAs-followed-by-a-project-name";
     private static final String displayName = "Pretty name that has some actual meaning";
+    private static final String SUCCESSFUL = "successful";
+    private static final String FAILING = "failing";
+    private static final String RUNNING = "running";
 
     private RelativeLocation relativeLocation = mock(RelativeLocation.class); // TODO recipe builder
     private JobView view;
@@ -212,7 +215,7 @@ public class JobViewTest {
         view = a(jobView().of(
                 a(job().whereTheLast(build().finishedWith(SUCCESS)))));
 
-        assertThat(view.status(), containsString("successful"));
+        assertThat(view.status(), containsString(SUCCESSFUL));
     }
 
     @Test
@@ -221,7 +224,7 @@ public class JobViewTest {
             view = a(jobView().of(
                     a(job().whereTheLast(build().finishedWith(result)))));
 
-            assertThat(view.status(), containsString("failing"));
+            assertThat(view.status(), containsString(FAILING));
         }
     }
 
@@ -248,7 +251,7 @@ public class JobViewTest {
                 a(jobView().of(a(job().whereTheLast(build().isStillUpdatingTheLog())))));
 
         for (JobView view : views) {
-            assertThat(view.status(), containsString("running"));
+            assertThat(view.status(), containsString(RUNNING));
         }
     }
 
@@ -264,7 +267,7 @@ public class JobViewTest {
         view = a(jobView().of(a(job().thatIsNotBuildable().whereTheLast(build().finishedWith(FAILURE)))));
 
         assertThat(view.status(), containsString("disabled"));
-        assertThat(view.status(), containsString("failing"));
+        assertThat(view.status(), containsString(FAILING));
     }
 
     @Test
@@ -279,8 +282,8 @@ public class JobViewTest {
         // but then it would require Java 7
 
         for (JobView view : views) {
-            assertThat(view.status(), containsString("successful"));
-            assertThat(view.status(), containsString("running"));
+            assertThat(view.status(), containsString(SUCCESSFUL));
+            assertThat(view.status(), containsString(RUNNING));
         }
     }
 
@@ -299,8 +302,8 @@ public class JobViewTest {
         );
 
         for (JobView view : views) {
-            assertThat(view.status(), containsString("failing"));
-            assertThat(view.status(), containsString("running"));
+            assertThat(view.status(), containsString(FAILING));
+            assertThat(view.status(), containsString(RUNNING));
         }
     }
 
@@ -315,7 +318,7 @@ public class JobViewTest {
                         andThePrevious(build().isStillBuilding()).
                         andThePrevious(build().finishedWith(SUCCESS)))));
 
-        assertThat(view.status(), containsString("successful"));
+        assertThat(view.status(), containsString(SUCCESSFUL));
     }
 
     @Test

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/readability/ListerTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/readability/ListerTest.java
@@ -10,6 +10,9 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 public class ListerTest {
+    private static final String APPLE = "apple";
+    private static final String ORANGE = "orange";
+    private static final String FRUITS_FORMAT = "Fruits: %s";
 
     @Test
     public void should_return_an_empty_string_when_given_an_empty_list() throws Exception {
@@ -18,32 +21,32 @@ public class ListerTest {
 
     @Test
     public void should_return_a_string_representation_of_a_given_object() throws Exception {
-        assertThat(Lister.asString(listOf("apple")), is("apple"));
+        assertThat(Lister.asString(listOf(APPLE)), is(APPLE));
     }
 
     @Test
     public void should_use_and_instead_of_a_comma_before_the_last_item() throws Exception {
-        assertThat(Lister.asString(listOf("apple", "orange")), is("apple and orange"));
+        assertThat(Lister.asString(listOf(APPLE, ORANGE)), is("apple and orange"));
     }
 
     @Test
     public void should_use_comma_to_delimit_all_the_elements_except_the_last_one() throws Exception {
-        assertThat(Lister.asString(listOf("apple", "orange", "banana")), is("apple, orange and banana"));
+        assertThat(Lister.asString(listOf(APPLE, ORANGE, "banana")), is("apple, orange and banana"));
     }
 
     @Test
     public void should_use_an_optional_template_to_describe_a_list_with_multiple_items() throws Exception {
-        assertThat(Lister.describe("Fruits: %s", listOf("apple", "orange")), is("Fruits: apple and orange"));
+        assertThat(Lister.describe(FRUITS_FORMAT, listOf(APPLE, ORANGE)), is("Fruits: apple and orange"));
     }
 
     @Test
     public void should_say_when_the_list_has_no_items() throws Exception {
-        assertThat(Lister.describe("No fruit for you today :-(", "Fruits: %s", listOf()), is("No fruit for you today :-("));
+        assertThat(Lister.describe("No fruit for you today :-(", FRUITS_FORMAT, listOf()), is("No fruit for you today :-("));
     }
 
     @Test
     public void should_allow_to_use_a_different_template_to_describe_a_list_with_one_item() throws Exception {
-        assertThat(Lister.describe("Empty", "%s fruit", "Fruits: %s", listOf("apple")), is("apple fruit"));
+        assertThat(Lister.describe("Empty", "%s fruit", FRUITS_FORMAT, listOf(APPLE)), is("apple fruit"));
     }
 
     private <T> List<T> listOf(T... items) {

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/readability/PluraliserTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/readability/PluraliserTest.java
@@ -7,24 +7,28 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 public class PluraliserTest {
+    private static final String APPLES_FORMAT="%s apples";
+    private static final String APPLE_FORMAT="%s apple";
+    private static final String NO_APPLES="no apples :-(";
+
     @Test
     public void should_use_the_plural_format_if_no_other_is_specified() throws Exception {
-        assertThat(Pluraliser.pluralise("%s apples", 0), is("0 apples"));
-        assertThat(Pluraliser.pluralise("%s apples", 1), is("1 apples")); // eek, said the grammar geek! ;-)
-        assertThat(Pluraliser.pluralise("%s apples", 5), is("5 apples"));
+        assertThat(Pluraliser.pluralise(APPLES_FORMAT, 0), is("0 apples"));
+        assertThat(Pluraliser.pluralise(APPLES_FORMAT, 1), is("1 apples")); // eek, said the grammar geek! ;-)
+        assertThat(Pluraliser.pluralise(APPLES_FORMAT, 5), is("5 apples"));
     }
 
     @Test
     public void should_use_a_singular_format_if_the_count_equals_one() throws Exception {
-        assertThat(Pluraliser.pluralise("%s apple", "%s apples", 0), is("0 apples"));
-        assertThat(Pluraliser.pluralise("%s apple", "%s apples", 1), is("1 apple"));
-        assertThat(Pluraliser.pluralise("%s apple", "%s apples", 5), is("5 apples"));
+        assertThat(Pluraliser.pluralise(APPLE_FORMAT, APPLES_FORMAT, 0), is("0 apples"));
+        assertThat(Pluraliser.pluralise(APPLE_FORMAT, APPLES_FORMAT, 1), is("1 apple"));
+        assertThat(Pluraliser.pluralise(APPLE_FORMAT, APPLES_FORMAT, 5), is("5 apples"));
     }
 
     @Test
     public void should_use_a_correct_format_depending_on_the_count_provided() throws Exception {
-        assertThat(Pluraliser.pluralise("no apples :-(", "%s apple", "%s apples", 0), is("no apples :-("));
-        assertThat(Pluraliser.pluralise("no apples :-(", "%s apple", "%s apples", 1), is("1 apple"));
-        assertThat(Pluraliser.pluralise("no apples :-(", "%s apple", "%s apples", 5), is("5 apples"));
+        assertThat(Pluraliser.pluralise(NO_APPLES, APPLE_FORMAT, APPLES_FORMAT, 0), is(NO_APPLES));
+        assertThat(Pluraliser.pluralise(NO_APPLES, APPLE_FORMAT, APPLES_FORMAT, 1), is("1 apple"));
+        assertThat(Pluraliser.pluralise(NO_APPLES, APPLE_FORMAT, APPLES_FORMAT, 5), is("5 apples"));
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1192 - “String literals should not be duplicated”. 
This PR will reduce 120 min TD.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
Soso Tughushi