### PR TITLE
Fix: squid:S1118: Utility classes should not have public constructors

### DIFF
--- a/build-monitor-acceptance/src/main/java/com/cloudbees/hudson/plugins/folder/user_interface/FolderDetailsPage.java
+++ b/build-monitor-acceptance/src/main/java/com/cloudbees/hudson/plugins/folder/user_interface/FolderDetailsPage.java
@@ -4,5 +4,6 @@ import net.serenitybdd.screenplay.jenkins.targets.Link;
 import net.serenitybdd.screenplay.targets.Target;
 
 public class FolderDetailsPage {
+    private FolderDetailsPage(){}
     public static final Target Up_Link = Link.called("Up");
 }

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/matchers/ProjectInformationMatchers.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/matchers/ProjectInformationMatchers.java
@@ -8,6 +8,9 @@ import org.hamcrest.TypeSafeMatcher;
 import static java.lang.String.format;
 
 public class ProjectInformationMatchers {
+
+    private ProjectInformationMatchers() {}
+
     public static ProjectStatusMatcher displaysProjectStatusAs(ProjectStatus desiredStatus) {
         return new ProjectStatusMatcher(desiredStatus);
     }

--- a/build-monitor-acceptance/src/main/java/com/sonyericsson/jenkins/plugins/bfa/user_interface/FailureCauseManagementPage.java
+++ b/build-monitor-acceptance/src/main/java/com/sonyericsson/jenkins/plugins/bfa/user_interface/FailureCauseManagementPage.java
@@ -6,6 +6,9 @@ import net.serenitybdd.screenplay.jenkins.targets.Link;
 import net.serenitybdd.screenplay.targets.Target;
 
 public class FailureCauseManagementPage {
+
+    private FailureCauseManagementPage(){}
+
     public static final Target Create_New_Link = Link.called("Create new");
     public static final Target Name            = Setting.defining("Name"); //Target.the("Name field").locatedBy("//*[@name='_.name']");
     public static final Target Description     = Setting.defining("Description"); //Target.the("Description field").locatedBy("//*[@name='_.description']");

--- a/build-monitor-acceptance/src/main/java/com/sonyericsson/jenkins/plugins/bfa/user_interface/JenkinsHomePageWithBFA.java
+++ b/build-monitor-acceptance/src/main/java/com/sonyericsson/jenkins/plugins/bfa/user_interface/JenkinsHomePageWithBFA.java
@@ -4,5 +4,8 @@ import net.serenitybdd.screenplay.jenkins.targets.Link;
 import net.serenitybdd.screenplay.targets.Target;
 
 public class JenkinsHomePageWithBFA {
+
+    private JenkinsHomePageWithBFA(){}
+
     public static final Target Failure_Cause_Management_Link = Link.called("Failure Cause Management");
 }

--- a/build-monitor-acceptance/src/main/java/hudson/plugins/claim/user_interface/ClaimableBuildDetailsPage.java
+++ b/build-monitor-acceptance/src/main/java/hudson/plugins/claim/user_interface/ClaimableBuildDetailsPage.java
@@ -6,6 +6,8 @@ import net.serenitybdd.screenplay.jenkins.targets.Setting;
 import net.serenitybdd.screenplay.targets.Target;
 
 public class ClaimableBuildDetailsPage {
+    private ClaimableBuildDetailsPage() {}
+
     public static final Target Claim_It_Link = Link.called("Claim it");
     public static final Target Claim_Button  = Button.called("Claim");
     public static final Target Reason_Field  = Setting.defining("Reason");

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/JenkinsArtifactTransporter.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/JenkinsArtifactTransporter.java
@@ -7,6 +7,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class JenkinsArtifactTransporter {
+    private JenkinsArtifactTransporter(){}
+
     public static ArtifactTransporter create() {
         return new ArtifactTransporter(
                 pathToLocalMavenRepository(),

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/Directories.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/Directories.java
@@ -6,5 +6,6 @@ import java.nio.file.Paths;
 import static java.lang.System.getProperty;
 
 public class Directories {
+    private Directories(){}
     public static final Path Default_Temp_Dir = Paths.get(getProperty("java.io.tmpdir"));
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/InstallPlugins.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/InstallPlugins.java
@@ -3,6 +3,8 @@ package net.serenitybdd.integration.jenkins.environment.rules;
 import java.nio.file.Path;
 
 public class InstallPlugins {
+    private InstallPlugins(){}
+
     public static InstallPluginsFromDisk fromDisk(Path... locations) {
         return new InstallPluginsFromDisk(locations);
     }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/utils/CommandLineTools.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/utils/CommandLineTools.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import static net.serenitybdd.integration.utils.Nulls.coalesce;
 
 public class CommandLineTools {
+    private CommandLineTools(){}
     public static Path java() {
         Path javaBin = Paths.get(coalesce(
                 System.getenv("JENKINS_JAVA_HOME"),

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/utils/ListFunctions.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/utils/ListFunctions.java
@@ -8,6 +8,9 @@ import java.util.Collections;
 import java.util.List;
 
 public class ListFunctions {
+
+    private ListFunctions(){}
+
     public static <T> List<T> concat(List<? extends T>... lists) {
         if (lists.length == 0) {
             return Collections.EMPTY_LIST;

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/utils/Nulls.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/utils/Nulls.java
@@ -3,6 +3,9 @@ package net.serenitybdd.integration.utils;
 import javax.validation.constraints.NotNull;
 
 public class Nulls {
+
+    private Nulls(){}
+
     public static <T> T coalesce(T... items) {
         for(T i : items) if(i != null) return i;
         return null;

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/utils/RuleChains.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/utils/RuleChains.java
@@ -10,6 +10,7 @@ import static net.serenitybdd.integration.utils.ListFunctions.head;
 import static net.serenitybdd.integration.utils.ListFunctions.tail;
 
 public class RuleChains {
+    private RuleChains(){}
     public static RuleChain from(TestRule... rules) {
         return from(Arrays.asList(rules));
     }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/readability/Typograph.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/readability/Typograph.java
@@ -1,6 +1,8 @@
 package net.serenitybdd.readability;
 
 public class Typograph {
+    private Typograph(){}
+
     public static String deCamelCase(String camelCasedString) {
         return camelCasedString.replaceAll(
                 String.format("%s|%s|%s",

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/targets/Button.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/targets/Button.java
@@ -5,6 +5,7 @@ import net.serenitybdd.screenplay.targets.Target;
 import static java.lang.String.format;
 
 public class Button {
+    private Button(){}
     public static Target called(String text) {
         return Target.the(format("the '%s' button", text))
                 .locatedBy("//button[contains(.,'{0}')]")

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/targets/Checkbox.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/targets/Checkbox.java
@@ -5,6 +5,7 @@ import net.serenitybdd.screenplay.targets.Target;
 import static java.lang.String.format;
 
 public class Checkbox {
+    private Checkbox(){}
     public static Target withLabel(String text) {
         return Target.the(format("the '%s' checkbox", text))
                 .locatedBy("//*[label[contains(.,'{0}')]]/input[@type='checkbox']")

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/targets/Link.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/targets/Link.java
@@ -5,6 +5,7 @@ import net.serenitybdd.screenplay.targets.Target;
 import static java.lang.String.format;
 
 public class Link {
+    private Link(){}
     public static Target called(String text) {
         return to(text);
     }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/targets/RadioButton.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/targets/RadioButton.java
@@ -5,6 +5,8 @@ import net.serenitybdd.screenplay.targets.Target;
 import static java.lang.String.format;
 
 public class RadioButton {
+    private RadioButton(){}
+
     public static Target withLabel(String text) {
         return Target.the(format("the '%s' radio button", text))
                 .locatedBy("//*[label[contains(.,'{0}')]]/input[@type='radio']")

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/targets/Setting.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/targets/Setting.java
@@ -6,6 +6,8 @@ import net.serenitybdd.screenplay.targets.Target;
 import static java.lang.String.format;
 
 public class Setting {
+    private Setting(){}
+
     public static Target defining(String name) {
         return Target.the(format("the '%s' field", name))
                 .locatedBy(lastElementMatching(either(xpathFor("input"), xpathFor("textarea"))))

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/build_steps/ShellScriptThat.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/build_steps/ShellScriptThat.java
@@ -1,6 +1,7 @@
 package net.serenitybdd.screenplay.jenkins.tasks.configuration.build_steps;
 
 public class ShellScriptThat {
+    private ShellScriptThat(){}
     public static final ShellScript Finishes_With_Success = ShellScript.that("Finishes with success").definedAs("exit 0;");
     public static final ShellScript Finishes_With_Error   = ShellScript.that("Finishes with error").definedAs("exit 1;");
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/LogInForm.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/LogInForm.java
@@ -4,6 +4,7 @@ import net.serenitybdd.screenplay.jenkins.targets.Button;
 import net.serenitybdd.screenplay.targets.Target;
 
 public class LogInForm {
+    private LogInForm(){}
     public static final Target Username_Field = Target.the("the 'User' field").locatedBy("//input[@name='j_username']");
     public static final Target Password_Field = Target.the("the 'Password' field").locatedBy("//input[@name='j_password']");
     public static final Target Log_In_Buttton = Button.called("log in");

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/ProjectConfigurationPage.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/ProjectConfigurationPage.java
@@ -4,6 +4,7 @@ import net.serenitybdd.screenplay.jenkins.targets.Button;
 import net.serenitybdd.screenplay.targets.Target;
 
 public class ProjectConfigurationPage {
+    private ProjectConfigurationPage(){}
     public static final Target Add_Build_Step = Button.called("Add build step");
     public static final Target Add_Post_Build_Action = Button.called("Add post-build action");
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/ProjectDetailsPage.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/ProjectDetailsPage.java
@@ -4,5 +4,6 @@ import net.serenitybdd.screenplay.jenkins.targets.Link;
 import net.serenitybdd.screenplay.targets.Target;
 
 public class ProjectDetailsPage {
+    private ProjectDetailsPage(){}
     public static final Target Last_Failed_Build_Link = Link.called("Last failed build");
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/ViewConfigurationPage.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/ViewConfigurationPage.java
@@ -5,6 +5,7 @@ import net.serenitybdd.screenplay.jenkins.targets.Checkbox;
 import net.serenitybdd.screenplay.targets.Target;
 
 public class ViewConfigurationPage {
+    private ViewConfigurationPage(){}
     public static final Target Recurse_In_Subfolders = Target.the("the 'Recurse in subfolders' option").locatedBy("#recurse");
     public static final Target Use_Regular_Expression = Checkbox.withLabel("Use a regular expression to include jobs into the view");
     public static final Target Regular_Expression     = Target.the("the 'Regular expression' field").located(By.name("includeRegex"));

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/navigation/Breadcrumbs.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/navigation/Breadcrumbs.java
@@ -6,6 +6,8 @@ import net.serenitybdd.screenplay.targets.Target;
 import static java.lang.String.format;
 
 public class Breadcrumbs {
+    private Breadcrumbs(){}
+
     public static final Target Jenkins_Link = Link.to("Jenkins");
 
     public static Target linkTo(String name) {

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/navigation/Buttons.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/navigation/Buttons.java
@@ -4,6 +4,7 @@ import net.serenitybdd.screenplay.targets.Target;
 import net.serenitybdd.screenplay.jenkins.targets.Button;
 
 public class Buttons {
+    private Buttons(){}
     public static final Target Save = Button.called("Save");
     public static final Target OK   = Button.called("OK");
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/navigation/SidePanel.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/navigation/SidePanel.java
@@ -4,6 +4,8 @@ import net.serenitybdd.screenplay.targets.Target;
 import net.serenitybdd.screenplay.jenkins.targets.Link;
 
 public class SidePanel {
+    private SidePanel(){}
+
     public static final Target New_Item_Link = Link.to("New Item");
     public static final Target Back_to_Dashboard = Link.to("Back to Dashboard");
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/project_configuration/build_steps/ShellBuildStep.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/project_configuration/build_steps/ShellBuildStep.java
@@ -3,5 +3,6 @@ package net.serenitybdd.screenplay.jenkins.user_interface.project_configuration.
 import net.serenitybdd.screenplay.targets.Target;
 
 public class ShellBuildStep {
+    private ShellBuildStep(){}
     public static final Target Editor = Target.the("code editor").locatedBy("(//div[@class='CodeMirror'])[last()]");
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplayx/actions/Scroll.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplayx/actions/Scroll.java
@@ -3,6 +3,7 @@ package net.serenitybdd.screenplayx.actions;
 import net.serenitybdd.screenplay.targets.Target;
 
 public class Scroll {
+    private Scroll(){}
     public static ScrollToTarget to(Target target) {
         return new ScrollToTarget(target);
     }

--- a/build-monitor-acceptance/src/test/java/environment/JenkinsSandbox.java
+++ b/build-monitor-acceptance/src/test/java/environment/JenkinsSandbox.java
@@ -11,6 +11,8 @@ import net.serenitybdd.integration.jenkins.environment.rules.SandboxJenkinsHome;
 import static java.lang.System.getProperty;
 
 public class JenkinsSandbox {
+    private JenkinsSandbox(){}
+
     public static TestEnvironment configure() {
         CWD cwd = CWD.or(getProperty("project.root"));
 

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/api/Respond.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/api/Respond.java
@@ -9,6 +9,8 @@ import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.api.Success.succes
 import static net.sf.json.JSONSerializer.toJSON;
 
 public class Respond {
+    private Respond(){}
+
     private static ObjectMapper mapper = new ObjectMapper();
 
     public static <T> JSONObject withSuccess(T responseData) throws IOException {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/functions/NullSafety.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/functions/NullSafety.java
@@ -1,6 +1,7 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.functions;
 
 public class NullSafety {
+    private NullSafety(){}
 
     /**
      * @param value         a value that can be a potential null

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/readability/Lister.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/readability/Lister.java
@@ -5,6 +5,7 @@ import java.util.List;
 import static java.lang.String.format;
 
 public class Lister {
+    private Lister(){}
     private static final String DEFAULT_NO_ITEMS_TEMPLATE = "%s";
 
     public static <T> String describe(String pluralTemplate, List<T> items) {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/readability/Pluraliser.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/readability/Pluraliser.java
@@ -3,6 +3,8 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.readability;
 import static java.lang.String.format;
 
 public class Pluraliser {
+    private Pluraliser(){}
+
     public static String pluralise(String template, int count) {
         return format(template, count);
     }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/CssStatus.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/CssStatus.java
@@ -12,6 +12,8 @@ import static hudson.model.Result.*;
  */
 public class CssStatus {
 
+    private CssStatus(){}
+
     private final static Map<Result, String> statuses = new HashMap<Result, String>() {{
         put(SUCCESS,   "successful");
         put(UNSTABLE,  "unstable");

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugin/assetbundler/OsSpecific.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugin/assetbundler/OsSpecific.java
@@ -1,6 +1,8 @@
 package com.smartcodeltd.jenkinsci.plugin.assetbundler;
 
 public class OsSpecific {
+    private OsSpecific(){}
+
     public static boolean isWindows() {
         return System.getProperty("os.name").startsWith("Windows");
     }

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/Loops.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/Loops.java
@@ -11,7 +11,7 @@ import java.util.List;
  * @author Jan Molak
  */
 public class Loops {
-
+    private Loops(){}
     public static <T> List<T> asFollows(T... examples) {
         return Arrays.asList(examples);
     }

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/Sugar.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/Sugar.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class Sugar {
+    private Sugar(){}
 
     public static JobViewRecipe jobView() {
         return new JobViewRecipe();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Soso Tughushi