### PR TITLE
General code fix 2

### DIFF
--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/logging/LoggerOutputStream.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/logging/LoggerOutputStream.java
@@ -24,6 +24,7 @@ public class LoggerOutputStream extends OutputStream {
         }
     }
 
+    @Override
     public void flush() {
         witness.note(buffer);
         buffer = "";

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/process/JenkinsProcess.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/process/JenkinsProcess.java
@@ -110,10 +110,10 @@ public class JenkinsProcess {
     private Process start(ProcessBuilder jenkinsProcessBuilder) throws IOException {
         Log.info("Starting Jenkins on port {}...", port);
 
-        Process process = jenkinsProcessBuilder.start();
-        process.getOutputStream().close();
+        Process jenkinsProcess = jenkinsProcessBuilder.start();
+        jenkinsProcess.getOutputStream().close();
 
-        return process;
+        return jenkinsProcess;
     }
 
     private static String OS = System.getProperty("os.name").toLowerCase();

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildView.java
@@ -176,6 +176,7 @@ public class BuildView implements BuildViewModel {
         return augmentor.detailsOf(build, Analysis.class);
     }
 
+    @Override
     public String toString() {
         return name();
     }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
@@ -196,6 +196,7 @@ public class JobView {
         return Objects.hashCode(job.hashCode());
     }
 
+    @Override
     public String toString() {
         return name();
     }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/duration/Duration.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/duration/Duration.java
@@ -8,6 +8,7 @@ abstract public class Duration {
         this.duration = milliseconds;
     }
 
+    @Override
     abstract public String toString();
 
     public boolean greaterThan(Duration otherDuration) {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/bfa/Analysed.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/bfa/Analysed.java
@@ -27,6 +27,7 @@ public class Analysed implements Analysis {
         return failures;
     }
 
+    @Override
     public String toString() {
         return String.format("Failed with %s",failures());
     }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/bfa/NotAnalysed.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/bfa/NotAnalysed.java
@@ -14,6 +14,7 @@ public class NotAnalysed implements Analysis {
         return Collections.emptyList();
     }
 
+    @Override
     public String toString() {
         return "No known failures";
     }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/claim/Claimed.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/claim/Claimed.java
@@ -24,6 +24,7 @@ public class Claimed implements Claim {
         return action.getReason();
     }
 
+    @Override
     public String toString() {
         return String.format("Claimed by \"%s\": \"%s\"", author(), reason());
     }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/claim/NotClaimed.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/claim/NotClaimed.java
@@ -16,6 +16,7 @@ public class NotClaimed implements Claim {
         return null;
     }
 
+    @Override
     public String toString() {
         return "Not claimed";
     }

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewTest.java
@@ -247,8 +247,8 @@ public class JobViewTest {
                 a(jobView().of(a(job().whereTheLast(build().isStillBuilding())))),
                 a(jobView().of(a(job().whereTheLast(build().isStillUpdatingTheLog())))));
 
-        for (JobView view : views) {
-            assertThat(view.status(), containsString("running"));
+        for (JobView jobView : views) {
+            assertThat(jobView.status(), containsString("running"));
         }
     }
 
@@ -278,9 +278,9 @@ public class JobViewTest {
         // assertThat(view.status(), both(containsString("successful")).and(containsString("running")));
         // but then it would require Java 7
 
-        for (JobView view : views) {
-            assertThat(view.status(), containsString("successful"));
-            assertThat(view.status(), containsString("running"));
+        for (JobView jobView : views) {
+            assertThat(jobView.status(), containsString("successful"));
+            assertThat(jobView.status(), containsString("running"));
         }
     }
 
@@ -298,9 +298,9 @@ public class JobViewTest {
                         andThePrevious(build().finishedWith(FAILURE)))))
         );
 
-        for (JobView view : views) {
-            assertThat(view.status(), containsString("failing"));
-            assertThat(view.status(), containsString("running"));
+        for (JobView jobView : views) {
+            assertThat(jobView.status(), containsString("failing"));
+            assertThat(jobView.status(), containsString("running"));
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules

squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one.

squid:HiddenFieldCheck - Local variables should not shadow class fields.

You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/S1161 
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck

Please let me know if you have any questions.

Soso Tughushi