### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order (part 1)

### DIFF
--- a/build-monitor-acceptance/src/main/java/com/cloudbees/hudson/plugins/folder/HaveAFolderCreated.java
+++ b/build-monitor-acceptance/src/main/java/com/cloudbees/hudson/plugins/folder/HaveAFolderCreated.java
@@ -11,6 +11,12 @@ import net.thucydides.core.annotations.Step;
 import static net.serenitybdd.screenplay.Tasks.instrumented;
 
 public class HaveAFolderCreated implements Task {
+    private final String name;
+    private final TodoList configurationTasks = TodoList.empty();
+
+    public HaveAFolderCreated(String name) {
+        this.name = name;
+    }
 
     public static HaveAFolderCreated called(String name) {
         return instrumented(HaveAFolderCreated.class, name);
@@ -31,11 +37,4 @@ public class HaveAFolderCreated implements Task {
                 Click.on(FolderDetailsPage.Up_Link)
         );
     }
-
-    public HaveAFolderCreated(String name) {
-        this.name = name;
-    }
-
-    private final String name;
-    private final TodoList configurationTasks = TodoList.empty();
 }

--- a/build-monitor-acceptance/src/main/java/com/cloudbees/hudson/plugins/folder/HaveANestedProjectCreated.java
+++ b/build-monitor-acceptance/src/main/java/com/cloudbees/hudson/plugins/folder/HaveANestedProjectCreated.java
@@ -11,6 +11,12 @@ import static net.serenitybdd.screenplay.Tasks.instrumented;
 
 public class HaveANestedProjectCreated implements Task {
 
+    private final String projectName;
+
+    public HaveANestedProjectCreated(String projectName) {
+        this.projectName = projectName;
+    }
+
     public static Task called(String name) {
         return instrumented(HaveANestedProjectCreated.class, name);
     }
@@ -24,9 +30,5 @@ public class HaveANestedProjectCreated implements Task {
         );
     }
 
-    public HaveANestedProjectCreated(String projectName) {
-        this.projectName = projectName;
-    }
 
-    private final String projectName;
 }

--- a/build-monitor-acceptance/src/main/java/com/cloudbees/hudson/plugins/folder/tasks/CreateAFolder.java
+++ b/build-monitor-acceptance/src/main/java/com/cloudbees/hudson/plugins/folder/tasks/CreateAFolder.java
@@ -15,6 +15,13 @@ import static net.serenitybdd.screenplay.jenkins.user_interface.navigation.Butto
 import static org.openqa.selenium.Keys.ENTER;
 
 public class CreateAFolder implements Task {
+
+    private final String name;
+
+    public CreateAFolder(String jobName) {
+        this.name = jobName;
+    }
+
     public static CreateAFolder called(String name) {
         return instrumented(CreateAFolder.class, name);
     }
@@ -30,9 +37,4 @@ public class CreateAFolder implements Task {
         );
     }
 
-    public CreateAFolder(String jobName) {
-        this.name = jobName;
-    }
-
-    private final String   name;
 }

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/aether/RemoteRepository.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/aether/RemoteRepository.java
@@ -4,16 +4,20 @@ import java.net.URI;
 
 public class RemoteRepository {
 
-    public static RemoteRepository at(String url) {
-        URI remote = URI.create(url);
-
-        return new RemoteRepository(remote.getHost(), "default", remote.toString());
-    }
+    private final String id;
+    private final String type;
+    private final String url;
 
     public RemoteRepository(String id, String type, String url) {
         this.id = id;
         this.type = type;
         this.url = url;
+    }
+
+    public static RemoteRepository at(String url) {
+        URI remote = URI.create(url);
+
+        return new RemoteRepository(remote.getHost(), "default", remote.toString());
     }
 
     public String id() {
@@ -27,8 +31,4 @@ public class RemoteRepository {
     public String url() {
         return url;
     }
-
-    private final String id;
-    private final String type;
-    private final String url;
 }

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/ProjectWidget.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/ProjectWidget.java
@@ -9,6 +9,12 @@ import net.serenitybdd.screenplay.Question;
 
 public class ProjectWidget {
 
+    private final String projectOfInterest;
+
+    public ProjectWidget(String projectOfInterest) {
+        this.projectOfInterest = projectOfInterest;
+    }
+
     public static ProjectWidget of(String projectOfInterest) {
         return new ProjectWidget(projectOfInterest);
     }
@@ -25,9 +31,4 @@ public class ProjectWidget {
         return new ProjectWidgetDetails(projectOfInterest);
     }
 
-    public ProjectWidget(String projectOfInterest) {
-        this.projectOfInterest = projectOfInterest;
-    }
-
-    private final String projectOfInterest;
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.
Soso Tughushi