### PR TITLE
[squid:ModifiersOrderCheck] Modifiers should be declared in the correct order

### DIFF
--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/client/JenkinsClient.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/client/JenkinsClient.java
@@ -20,8 +20,8 @@ import static java.lang.String.format;
 import static net.serenitybdd.integration.jenkins.process.JenkinsProcess.JENKINS_IS_FULLY_UP_AND_RUNNING;
 
 public class JenkinsClient {
-    private final static Logger logger = LoggerFactory.getLogger(JenkinsClient.class);
-    private final static int Max_Wait_Time = 5 * 60 * 1000;
+    private static final Logger logger = LoggerFactory.getLogger(JenkinsClient.class);
+    private static final int Max_Wait_Time = 5 * 60 * 1000;
 
     private final JenkinsProcess process;
     private final JenkinsClientExecutor executor;

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/UpdateCenter.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/UpdateCenter.java
@@ -12,7 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class UpdateCenter {
-    private final static String Update_Center_URL_Template
+    private static final String Update_Center_URL_Template
             = "https://updates.jenkins-ci.org/update-center.json?id=default&version=%s";
     private final Path tempDir;
 

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/FindFreePort.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/FindFreePort.java
@@ -16,8 +16,8 @@ import static java.lang.String.format;
 public class FindFreePort implements ApplicativeTestRule<JenkinsInstance> {
     private static final Logger Log = LoggerFactory.getLogger(FindFreePort.class);
 
-    private final static int Dynamic_Range_Start = 49152;
-    private final static int Dynamic_Range_End   = 65535;
+    private static final int Dynamic_Range_Start = 49152;
+    private static final int Dynamic_Range_End   = 65535;
 
     private final int rangeStart;
     private final int rangeEnd;

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/InstallPluginsFromDisk.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/InstallPluginsFromDisk.java
@@ -17,7 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Arrays.asList;
 
 public class InstallPluginsFromDisk implements ApplicativeTestRule<JenkinsInstance> {
-    private final static Logger Log = LoggerFactory.getLogger(InstallPluginsFromDisk.class);
+    private static final Logger Log = LoggerFactory.getLogger(InstallPluginsFromDisk.class);
 
     private final List<Path> pluginsToInstall;
 

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/InstallPluginsFromUpdateCenter.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/InstallPluginsFromUpdateCenter.java
@@ -18,7 +18,7 @@ import static java.util.Arrays.asList;
 
 public class InstallPluginsFromUpdateCenter implements ApplicativeTestRule<JenkinsInstance> {
 
-    private final static Logger Log = LoggerFactory.getLogger(InstallPluginsFromUpdateCenter.class);
+    private static final Logger Log = LoggerFactory.getLogger(InstallPluginsFromUpdateCenter.class);
 
     private final UpdateCenter updateCenter = new UpdateCenter();
 

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/SandboxJenkinsHome.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/SandboxJenkinsHome.java
@@ -14,7 +14,7 @@ import java.nio.file.Path;
 import static java.lang.String.format;
 
 public class SandboxJenkinsHome implements ApplicativeTestRule<JenkinsInstance> {
-    private final static Logger Log = LoggerFactory.getLogger(SandboxJenkinsHome.class);
+    private static final Logger Log = LoggerFactory.getLogger(SandboxJenkinsHome.class);
 
     private final Path rootDirectory;
 

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/process/JenkinsLogWatcher.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/process/JenkinsLogWatcher.java
@@ -11,7 +11,7 @@ import java.util.regex.Matcher;
 
 class JenkinsLogWatcher implements AutoCloseable, Runnable {
 
-    private final static Logger Log = LoggerFactory.getLogger(JenkinsLogWatcher.class);
+    private static final Logger Log = LoggerFactory.getLogger(JenkinsLogWatcher.class);
 
     private final InputStream jenkinsOutput;
     private final List<JenkinsLogLineWatcher> watchers = new CopyOnWriteArrayList<>();

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/process/JenkinsProcess.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/process/JenkinsProcess.java
@@ -14,8 +14,8 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
 public class JenkinsProcess {
-    private final static Logger Log = LoggerFactory.getLogger(JenkinsProcess.class);
-    private final static int Startup_Timeout = 5 * 60 * 1000;
+    private static final Logger Log = LoggerFactory.getLogger(JenkinsProcess.class);
+    private static final int Startup_Timeout = 5 * 60 * 1000;
     public static final String JENKINS_IS_FULLY_UP_AND_RUNNING = "Jenkins is fully up and running";
 
     private final ProcessBuilder process;

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/facade/RelativeLocation.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/facade/RelativeLocation.java
@@ -10,7 +10,7 @@ import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
 public class RelativeLocation {
-    final private Job job;
+    private final Job job;
 
     public static RelativeLocation of(Job job) {
         return new RelativeLocation(job);

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/installation/BuildMonitorBuildProperties.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/installation/BuildMonitorBuildProperties.java
@@ -9,7 +9,7 @@ import java.util.Properties;
 public class BuildMonitorBuildProperties {
     private static final BuildMonitorLogger logger = BuildMonitorLogger.forClass(BuildMonitorBuildProperties.class);
 
-    final private Properties properties = new java.util.Properties();
+    private final Properties properties = new java.util.Properties();
 
     public BuildMonitorBuildProperties(String file) {
         try {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/CssStatus.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/CssStatus.java
@@ -12,7 +12,7 @@ import static hudson.model.Result.*;
  */
 public class CssStatus {
 
-    private final static Map<Result, String> statuses = new HashMap<Result, String>() {{
+    private static final Map<Result, String> statuses = new HashMap<Result, String>() {{
         put(SUCCESS,   "successful");
         put(UNSTABLE,  "unstable");
         put(FAILURE,   "failing");

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/duration/Duration.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/duration/Duration.java
@@ -1,6 +1,6 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.duration;
 
-abstract public class Duration {
+public abstract class Duration {
 
     protected final long duration;
 
@@ -8,7 +8,7 @@ abstract public class Duration {
         this.duration = milliseconds;
     }
 
-    abstract public String toString();
+    public abstract String toString();
 
     public boolean greaterThan(Duration otherDuration) {
         return duration > otherDuration.toLong();

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/duration/HumanReadableDuration.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/duration/HumanReadableDuration.java
@@ -2,10 +2,10 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.duration;
 
 // todo: is this still needed? backend could pass the duration in milliseconds to the frontend, which in turn could make it human-readable
 public class HumanReadableDuration extends Duration {
-    private final static long MILLISECOND = 1;
-    private final static long SECONDS = 1000 * MILLISECOND;
-    private final static long MINUTES = 60 * SECONDS;
-    private final static long HOURS = 60 * MINUTES;
+    private static final long MILLISECOND = 1;
+    private static final long SECONDS = 1000 * MILLISECOND;
+    private static final long MINUTES = 60 * SECONDS;
+    private static final long HOURS = 60 * MINUTES;
 
     public HumanReadableDuration(long milliseconds) {
         super(milliseconds);

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/bfa/AnalysedTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/bfa/AnalysedTest.java
@@ -14,8 +14,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class AnalysedTest {
-    private final static String FAILURE1_NAME = "JMS Server Down";
-    private final static String FAILURE2_NAME = "Unit test failures";
+    private static final String FAILURE1_NAME = "JMS Server Down";
+    private static final String FAILURE2_NAME = "Unit test failures";
 
     @Test
     public void should_be_a_simple_proxy_to_the_claim_build_action() throws Exception {

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/claim/ClaimedTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/plugins/claim/ClaimedTest.java
@@ -9,9 +9,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ClaimedTest {
-    private final static String AUTHOR = "Adam";
-    private final static String REASON = "I broke it, sorry, fixing now.";
-    private final static String EXPECTED_STRING_REPRESENTATION = String.format("Claimed by \"%s\": \"%s\"", AUTHOR, REASON);
+    private static final String AUTHOR = "Adam";
+    private static final String REASON = "I broke it, sorry, fixing now.";
+    private static final String EXPECTED_STRING_REPRESENTATION = String.format("Claimed by \"%s\": \"%s\"", AUTHOR, REASON);
 
     @Test
     public void should_be_a_simple_proxy_to_the_claim_build_action() throws Exception {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”.

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.
Soso Tughushi.