### PR TITLE
Make it work with IE.

### DIFF
--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
@@ -7,6 +7,7 @@
     <j:new var="h" className="hudson.Functions"/>
     ${h.initPageVariables(context)}
 
+    <j:set var="isMSIE" value="${userAgent.contains('MSIE')}"/>
     <j:set var="resourcesURL" value="${resURL}/plugin/build-monitor-plugin" />
     <j:set var="jobsURL" value="${rootURL}/job" />
     <j:set var="angularVersion" value="1.5.8" />


### PR DESCRIPTION
Required if web site is configured for Compatibility View. Some companies have IE configured to display intranet sites in compatibility view.