### PR TITLE
#265 Correct build status for External Job projects

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
@@ -86,11 +86,15 @@ public class JobView {
     }
 
     public boolean isDisabled() {
-        return ! isJobBuildable();
+        return ! (isJobBuildable() || isJobExternal());
     }
 
     private boolean isJobBuildable() {
         return job.isBuildable();
+    }
+
+    private boolean isJobExternal() {
+        return job instanceof hudson.model.ViewJob;
     }
 
     public boolean isRunning() {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
@@ -86,7 +86,11 @@ public class JobView {
     }
 
     public boolean isDisabled() {
-        return ! job.isBuildable();
+        return ! isJobBuildable();
+    }
+
+    private boolean isJobBuildable() {
+        return job.isBuildable();
     }
 
     public boolean isRunning() {

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewTest.java
@@ -11,6 +11,7 @@ import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacti
 import static hudson.model.Result.*;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -176,6 +177,13 @@ public class JobViewTest {
         view = a(jobView().of(a(job().thatIsNotBuildable())));
 
         assertThat(view.status(), containsString("disabled"));
+    }
+
+    @Test
+    public void should_describe_the_job_as_enabled_if_external_job() {
+        view = a(jobView().of(a(job().thatIsAnExternalJob())));
+
+        assertThat(view.status(), not(containsString("disabled")));
     }
 
     @Test

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/JobStateRecipe.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/JobStateRecipe.java
@@ -4,6 +4,7 @@ import com.google.common.base.Supplier;
 import hudson.model.AbstractBuild;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
+import hudson.model.ViewJob;
 
 import java.util.Stack;
 
@@ -58,6 +59,14 @@ public class JobStateRecipe implements Supplier<Job<?,?>> {
     }
 
     public JobStateRecipe thatIsNotBuildable() {
+        when(job.isBuildable()).thenReturn(Boolean.FALSE);
+
+        return this;
+    }
+
+    public JobStateRecipe thatIsAnExternalJob() {
+        job = mock(ViewJob.class);
+
         when(job.isBuildable()).thenReturn(Boolean.FALSE);
 
         return this;


### PR DESCRIPTION
This PR fixes #265 by considering jobs of type [``hudson.model.ViewJob``](http://javadoc.jenkins-ci.org/hudson/model/ViewJob.html) enabled by default.