### PR TITLE
adding text only groovy postbuild badges

### DIFF
--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/ProjectWidget.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/ProjectWidget.java
@@ -1,6 +1,7 @@
 package com.smartcodeltd.jenkinsci.plugins.build_monitor.questions;
 
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.model.ProjectInformation;
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.project_widget.ProjectBadgesState;
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.project_widget.ProjectWidgetDetails;
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.project_widget.ProjectWidgetInformation;
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.project_widget.ProjectWidgetState;
@@ -23,6 +24,10 @@ public class ProjectWidget {
 
     public Question<String> details() {
         return new ProjectWidgetDetails(projectOfInterest);
+    }
+
+    public Question<WebElementState> badges() {
+        return new ProjectBadgesState(projectOfInterest);
     }
 
     public ProjectWidget(String projectOfInterest) {

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/project_widget/ProjectBadgesState.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/project_widget/ProjectBadgesState.java
@@ -1,0 +1,27 @@
+package com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.project_widget;
+
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.user_interface.BuildMonitorDashboard;
+import net.serenitybdd.core.pages.WebElementState;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Question;
+import net.serenitybdd.screenplay.annotations.Subject;
+import net.serenitybdd.screenplay.targets.Target;
+
+import static net.serenitybdd.screenplay.questions.WebElementQuestion.stateOf;
+
+@Subject("the badges of widget representing the '#projectName' project on the Build Monitor")
+public class ProjectBadgesState implements Question<WebElementState> {
+
+    @Override
+    public WebElementState answeredBy(Actor actor) {
+        Target widget     = BuildMonitorDashboard.Project_Widget_Badges.of(projectName);
+
+        return stateOf(widget).answeredBy(actor);
+    }
+
+    public ProjectBadgesState(String projectName) {
+        this.projectName = projectName;
+    }
+
+    private final String projectName;
+}

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/ModifyControlPanelOptions.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/ModifyControlPanelOptions.java
@@ -1,0 +1,38 @@
+package com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks;
+
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.user_interface.BuildMonitorDashboard;
+
+import net.serenitybdd.screenplay.jenkins.tasks.configuration.TodoList;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Performable;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplay.actions.Click;
+import net.thucydides.core.annotations.Step;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static net.serenitybdd.screenplay.Tasks.instrumented;
+
+public class ModifyControlPanelOptions implements Task {
+
+    public static ModifyControlPanelOptions to(Task... configurationTasks) {
+        return instrumented(ModifyControlPanelOptions.class, asList(configurationTasks));
+    }
+
+    @Override
+    @Step("{0} modifies the Build Monitor View control panel options")
+    public <T extends Actor> void performAs(T actor) {
+        actor.attemptsTo(
+                Click.on(BuildMonitorDashboard.Control_Panel),
+                configureTheView,
+                Click.on(BuildMonitorDashboard.Control_Panel)
+        );
+    }
+
+    public ModifyControlPanelOptions(List<Performable> actions) {
+        this.configureTheView.addAll(actions);
+    }
+
+    private TodoList configureTheView = TodoList.empty();
+}

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/ShowBadges.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/ShowBadges.java
@@ -1,0 +1,24 @@
+package com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks;
+
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.user_interface.BuildMonitorDashboard;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplay.actions.Click;
+import net.thucydides.core.annotations.Step;
+
+import static net.serenitybdd.screenplay.Tasks.instrumented;
+
+public class ShowBadges implements Task {
+    public static Task onTheDashboard() {
+        return instrumented(ShowBadges.class);
+    }
+
+    @Step("{0} decides to display the badges on the dashboard")
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        actor.attemptsTo(
+                Click.on(BuildMonitorDashboard.Show_Badges)
+        );
+    }
+}

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/user_interface/BuildMonitorDashboard.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/user_interface/BuildMonitorDashboard.java
@@ -8,4 +8,8 @@ public class BuildMonitorDashboard extends PageObject {
     public static final Target Add_Some_Projects_link = Link.called("add some projects");
     public static final Target Project_Widget         = Target.the("Project Widget").locatedBy("//li[header/h2[.='{0}']]");
     public static final Target Project_Widget_Details = Target.the("Project Widget Details").locatedBy("//li[header/h2[.='{0}']]//*[@class='details']");
+    public static final Target Project_Widget_Badges  = Target.the("Project Widget Badges").locatedBy("//li[header/h2[.='{0}']]//*[@class='build-badge']");
+
+    public static final Target Control_Panel = Target.the("Control Panel").locatedBy("//label[@for='settings-toggle']");
+    public static final Target Show_Badges = Target.the("Show Badges Toggle").locatedBy("//input[@id='settings-show-badges']");
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/build_steps/AddAGroovyPostbuildScript.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/build_steps/AddAGroovyPostbuildScript.java
@@ -1,0 +1,31 @@
+package net.serenitybdd.screenplay.jenkins.tasks.configuration.build_steps;
+
+import net.serenitybdd.screenplay.jenkins.user_interface.project_configuration.build_steps.GroovyPostBuildStep;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplay.actions.Enter;
+import net.thucydides.core.annotations.Step;
+
+import static net.serenitybdd.screenplay.Tasks.instrumented;
+
+public class AddAGroovyPostbuildScript implements Task {
+
+    public static Task that(GroovyScript expectedOutcome) {
+        return instrumented(AddAGroovyPostbuildScript.class, expectedOutcome);
+    }
+
+    @Step("{0} configures the Groovy PostBuild Step to execute a script that '#scriptOutcome'")
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        actor.attemptsTo(
+        	AddAPostBuildAction.called("Groovy Postbuild"),
+            Enter.theValue(scriptOutcome.code()).into(GroovyPostBuildStep.Editor)
+        );
+    }
+
+    public AddAGroovyPostbuildScript(GroovyScript script) {
+        this.scriptOutcome = script;
+    }
+
+    private final GroovyScript scriptOutcome;
+}

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/build_steps/GroovyScript.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/build_steps/GroovyScript.java
@@ -1,0 +1,58 @@
+package net.serenitybdd.screenplay.jenkins.tasks.configuration.build_steps;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+import static com.google.common.collect.Lists.transform;
+import static java.util.Arrays.asList;
+
+public class GroovyScript {
+
+    public static GroovyScript that(String descriptionOfScriptsBehaviour) {
+        return new GroovyScript(descriptionOfScriptsBehaviour);
+    }
+
+    public GroovyScript definedAs(String... lines) {
+        return this.definedAs(asList(lines));
+    }
+
+    public GroovyScript definedAs(List<String> lines) {
+        this.code = Joiner.on('\n').join(lines);
+
+        return this;
+    }
+
+    public GroovyScript andOutputs(String... lines) {
+        return definedAs(transform(asList(lines), mapEachLineTo("echo \"%s\";")));
+    }
+
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+
+    private GroovyScript(String descriptionOfScriptsBehaviour) {
+        this.description = descriptionOfScriptsBehaviour;
+    }
+
+    private Function<String, String> mapEachLineTo(final String template) {
+        return new Function<String, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable String line) {
+                return String.format(template, line);
+            }
+        };
+    }
+
+    private final String description;
+
+    private String code = "";
+}

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/build_steps/GroovyScriptThat.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/build_steps/GroovyScriptThat.java
@@ -1,0 +1,5 @@
+package net.serenitybdd.screenplay.jenkins.tasks.configuration.build_steps;
+
+public class GroovyScriptThat {
+    public static final GroovyScript Adds_A_Badge = GroovyScript.that("Adds a badge").definedAs("manager.addShortText('Coverage', 'black', 'repeating-linear-gradient(45deg, yellow, yellow 10px, Orange 10px, Orange 20px)', '0px', 'white')");
+}

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/project_configuration/build_steps/GroovyPostBuildStep.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/project_configuration/build_steps/GroovyPostBuildStep.java
@@ -1,0 +1,7 @@
+package net.serenitybdd.screenplay.jenkins.user_interface.project_configuration.build_steps;
+
+import net.serenitybdd.screenplay.targets.Target;
+
+public class GroovyPostBuildStep {
+    public static final Target Editor = Target.the("code editor").locatedBy("(//div[@descriptorid='org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder']//textarea)[last()]");
+}

--- a/build-monitor-acceptance/src/test/java/features/ShouldDisplayBadges.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldDisplayBadges.java
@@ -1,0 +1,64 @@
+package features;
+
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.ProjectWidget;
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.HaveABuildMonitorViewCreated;
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.ModifyControlPanelOptions;
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.ShowBadges;
+import environment.JenkinsSandbox;
+import net.serenitybdd.integration.jenkins.JenkinsInstance;
+import net.serenitybdd.integration.jenkins.environment.rules.InstallPlugins;
+import net.serenitybdd.junit.runners.SerenityRunner;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import net.serenitybdd.screenplay.jenkins.HaveAProjectCreated;
+import net.serenitybdd.screenplay.jenkins.tasks.ScheduleABuild;
+import net.serenitybdd.screenplay.jenkins.tasks.configuration.build_steps.AddAGroovyPostbuildScript;
+import net.serenitybdd.screenplay.jenkins.tasks.configuration.build_steps.ExecuteAShellScript;
+import net.serenitybdd.screenplay.jenkins.tasks.configuration.build_steps.GroovyScriptThat;
+import net.serenitybdd.screenplayx.actions.Navigate;
+import net.thucydides.core.annotations.Managed;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+
+import static net.serenitybdd.screenplay.GivenWhenThen.*;
+import static net.serenitybdd.screenplay.jenkins.tasks.configuration.build_steps.ShellScriptThat.Finishes_With_Success;
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isCurrentlyVisible;
+
+@RunWith(SerenityRunner.class)
+public class ShouldDisplayBadges {
+
+    Actor paul = Actor.named("Paul");
+
+    @Managed public WebDriver hisBrowser;
+
+    @Rule public JenkinsInstance jenkins = JenkinsSandbox.configure().afterStart(
+            InstallPlugins.fromUpdateCenter("buildtriggerbadge", "groovy-postbuild")
+    ).create();
+
+    @Before
+    public void actorCanBrowseTheWeb() {
+        paul.can(BrowseTheWeb.with(hisBrowser));
+    }
+
+    @Test
+    public void display_build_badges() throws Exception {
+        givenThat(paul).wasAbleTo(
+                Navigate.to(jenkins.url()),
+                HaveAProjectCreated.called("My App").andConfiguredTo(
+                        ExecuteAShellScript.that(Finishes_With_Success),
+                        AddAGroovyPostbuildScript.that(GroovyScriptThat.Adds_A_Badge)
+                ),
+                ScheduleABuild.of("My App"),
+                HaveABuildMonitorViewCreated.showingAllTheProjects()
+        );
+
+        when(paul).attemptsTo(ModifyControlPanelOptions.to(ShowBadges.onTheDashboard()));
+
+        then(paul).should(seeThat(ProjectWidget.of("My App").badges(),
+        		isCurrentlyVisible()
+        ));
+    }
+}

--- a/build-monitor-plugin/pom.xml
+++ b/build-monitor-plugin/pom.xml
@@ -163,6 +163,12 @@
             <version>1.26</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jvnet.hudson.plugins</groupId>
+            <artifactId>groovy-postbuild</artifactId>
+            <version>2.3.1</version>
+            <optional>true</optional>
+        </dependency>
         <!-- /Jenkins CI plugins supported by the Build Monitor -->
 
         <dependency>

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildView.java
@@ -11,6 +11,7 @@ import hudson.model.*;
 import hudson.scm.ChangeLogSet;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -158,6 +159,11 @@ public class BuildView implements BuildViewModel {
     public <A extends Action> Optional<A> detailsOf(Class<A> jenkinsAction) {
         return Optional.fromNullable(build.getAction(jenkinsAction));
     }
+    
+    @Override
+	public <A extends Action> List<A> allDetailsOf(Class<A> jenkinsAction) {
+    	return build.getActions(jenkinsAction);
+	}
 
     @Override
     public String toString() {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildViewModel.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildViewModel.java
@@ -3,8 +3,10 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel;
 import com.google.common.base.Optional;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.duration.Duration;
 import hudson.model.Action;
+import hudson.model.BuildBadgeAction;
 import hudson.model.Result;
 
+import java.util.List;
 import java.util.Set;
 
 public interface BuildViewModel {
@@ -27,4 +29,5 @@ public interface BuildViewModel {
     Set<String> committers();
 
     <A extends Action> Optional<A> detailsOf(Class<A> jenkinsAction);
+    <A extends Action> List<A> allDetailsOf(Class<A> jenkinsAction);
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViews.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViews.java
@@ -15,6 +15,7 @@ import static com.google.common.collect.Lists.newArrayList;
 public class JobViews {
     public static final String Claim = "claim";
     public static final String Build_Failure_Analyzer = "build-failure-analyzer";
+    public static final String Groovy_Post_Build = "groovy-postbuild";
 
     private final StaticJenkinsAPIs jenkins;
     private final com.smartcodeltd.jenkinsci.plugins.buildmonitor.Config config;
@@ -37,6 +38,10 @@ public class JobViews {
 
         if (jenkins.hasPlugin(Build_Failure_Analyzer)) {
             viewFeatures.add(new CanBeDiagnosedForProblems());
+        }
+
+        if (jenkins.hasPlugin(Groovy_Post_Build)) {
+        	viewFeatures.add(new HasBadges());
         }
 
         return JobView.of(job, viewFeatures);

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/NullBuildView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/NullBuildView.java
@@ -3,9 +3,12 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel;
 import com.google.common.base.Optional;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.duration.Duration;
 import hudson.model.Action;
+import hudson.model.BuildBadgeAction;
 import hudson.model.Result;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class NullBuildView implements BuildViewModel {
@@ -84,4 +87,9 @@ public class NullBuildView implements BuildViewModel {
     public <A extends Action> Optional<A> detailsOf(Class<A> jenkinsAction) {
         return Optional.absent();
     }
+
+	@Override
+	public <A extends Action> List<A> allDetailsOf(Class<A> jenkinsAction) {
+		return new ArrayList<A>();
+	}
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasBadges.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasBadges.java
@@ -1,0 +1,98 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonValue;
+import org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildAction;
+
+/**
+ * @author Daniel Beland
+ */
+public class HasBadges implements Feature<HasBadges.Badges> {
+	private ActionFilter filter = new ActionFilter();
+	private JobView job;
+
+	public HasBadges() {
+	}
+
+	@Override
+	public HasBadges of(JobView jobView) {
+		this.job = jobView;
+
+		return this;
+	}
+
+	@Override
+	public Badges asJson() {
+		Iterator<GroovyPostbuildAction> badges = Iterables.filter(job.lastCompletedBuild().allDetailsOf(GroovyPostbuildAction.class), filter).iterator();
+
+		return badges.hasNext()
+				? new Badges(badges)
+				: null; // `null` because we don't want to serialise an empty object
+	}
+
+	public static class Badges {
+		private final List<Badge> badges = newArrayList();
+
+		public Badges(Iterator<GroovyPostbuildAction> badgeActions) {
+        	while (badgeActions.hasNext()) {
+        		badges.add(new Badge(badgeActions.next()));
+        	}
+		}
+		
+		@JsonValue
+		public List<Badge> value() {
+			return ImmutableList.copyOf(badges);
+		}
+	}
+	
+	public static class Badge {
+		private final GroovyPostbuildAction badge;
+		
+		public Badge(GroovyPostbuildAction badge) {
+        	this.badge = badge;
+		}
+		
+        @JsonProperty
+        public final String text() {
+            return badge.getText();
+        }
+
+        @JsonProperty
+        public final String color() {
+            return badge.getColor();
+        }
+
+        @JsonProperty
+        public final String background() {
+            return badge.getBackground();
+        }
+
+        @JsonProperty
+        public final String border() {
+            return badge.getBorder();
+        }
+
+        @JsonProperty
+        public final String borderColor() {
+            return badge.getBorderColor();
+        }
+	}
+	
+	private static class ActionFilter implements Predicate<GroovyPostbuildAction> {
+		@Override
+		public boolean apply(GroovyPostbuildAction action) {
+			return action.getIconPath() == null;
+		}
+	}
+
+}

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
@@ -34,6 +34,13 @@
                            id="settings-reduce-motion" type="checkbox" />
                     <label for="settings-reduce-motion" title="Reduces the amount of animation Build Monitor uses">Reduce motion?</label>
                 </li>
+                <li class="settings-option">
+                    <input ng-model="settings.showBadges"
+                           ng-false-value="'0'"
+                           ng-true-value="'1'"
+                           id="settings-show-badges" type="checkbox" />
+                    <label for="settings-show-badges" title="Show the last build badges">Show badges?</label>
+                </li>
                 <li class="buttons">
                     <a class="btn"
                        href="configure"

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/widgets.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/widgets.jelly
@@ -35,6 +35,9 @@
                         <li data-ng-repeat="name in project.problems">{{ name }}</li>
                     </ul>
                 </li>
+                <li data-ng-show="settings.showBadges == 1 &amp;&amp; !!project.badges" class="build-badge">
+                    <span data-ng-repeat="badge in project.badges track by $index" style="padding: 1px; border:{{ badge.border }} solid {{ badge.borderColor }}; margin: 0px; background: {{ badge.background }}; color: {{ badge.color }};">{{ badge.text }}</span>
+                </li>
             </ul>
         </header>
 

--- a/build-monitor-plugin/src/main/webapp/scripts/settings.js
+++ b/build-monitor-plugin/src/main/webapp/scripts/settings.js
@@ -9,6 +9,7 @@ angular.
             $scope.settings.numberOfColumns = cookieJar.get('numberOfColumns', 2);
             $scope.settings.colourBlind     = cookieJar.get('colourBlind',     0);
             $scope.settings.reduceMotion    = cookieJar.get('reduceMotion',    0);
+            $scope.settings.showBadges      = cookieJar.get('showBadges',      0);
 
             angular.forEach($scope.settings, function(value, name) {
                 $scope.$watch('settings.' + name, function(currentValue) {

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasBadgesTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasBadgesTest.java
@@ -1,0 +1,51 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
+
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+
+import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.*;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.URL;
+
+@PrepareForTest({URL.class})
+public class HasBadgesTest {
+    private JobView job;
+    
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void should_support_job_without_badges() throws Exception {
+    	job = a(jobView().which(new HasBadges()).of(
+                a(job())));
+
+        assertThat(serialisedBadgesDetailsOf(job), is(nullValue()));
+    }
+
+    @Test
+    public void should_convert_badges_to_json() throws Exception {
+    	job = a(jobView().which(new HasBadges()).of(
+                a(job().whereTheLast(build().hasBadges(badge().withText("badge1"), badge().withText("badge2"))))));
+
+        assertThat(serialisedBadgesDetailsOf(job).value(), hasSize(2));
+    }
+
+    @Test
+    public void should_ignore_badges_with_icon() throws Exception {
+    	job = a(jobView().which(new HasBadges()).of(
+                a(job().whereTheLast(build().hasBadges(badge().withIcon("icon.gif", "badge1"), badge().withText("badge2"))))));
+
+        assertThat(serialisedBadgesDetailsOf(job).value(), hasSize(1));
+    }
+
+    private HasBadges.Badges serialisedBadgesDetailsOf(JobView job) {
+        return job.which(HasBadges.class).asJson();
+    }
+}

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/BadgeRecipe.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/BadgeRecipe.java
@@ -1,0 +1,36 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar;
+
+import com.google.common.base.Supplier;
+
+import org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildAction;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Daniel Beland
+ */
+public class BadgeRecipe implements Supplier<GroovyPostbuildAction> {
+    private GroovyPostbuildAction badge;
+
+    public BadgeRecipe() {
+    	badge = mock(GroovyPostbuildAction.class);
+    }
+
+    public BadgeRecipe withText(String text) throws Exception {
+    	when(badge.getIconPath()).thenReturn(null);
+    	when(badge.getText()).thenReturn(text);
+        return this;
+    }
+
+    public BadgeRecipe withIcon(String icon, String text) throws Exception {
+    	when(badge.getIconPath()).thenReturn(icon);
+    	when(badge.getText()).thenReturn(text);
+        return this;
+    }
+
+    @Override
+    public GroovyPostbuildAction get() {
+        return badge;
+    }
+}

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/BuildStateRecipe.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/BuildStateRecipe.java
@@ -12,6 +12,8 @@ import hudson.plugins.claim.ClaimBuildAction;
 import hudson.scm.ChangeLogSet;
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.InterruptedBuildAction;
+
+import org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildAction;
 import org.powermock.api.mockito.PowerMockito;
 
 import java.text.SimpleDateFormat;
@@ -20,6 +22,7 @@ import java.util.Calendar;
 import java.util.Iterator;
 import java.util.List;
 
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -35,7 +38,7 @@ public class BuildStateRecipe implements Supplier<AbstractBuild<?, ?>> {
         build = mock(AbstractBuild.class);
 
         AbstractProject parent = mock(AbstractProject.class);
-        when(build.getParent()).thenReturn(parent);
+        doReturn(parent).when(build).getParent();
     }
 
     public BuildStateRecipe hasNumber(int number) {
@@ -194,6 +197,16 @@ public class BuildStateRecipe implements Supplier<AbstractBuild<?, ?>> {
         FoundFailureCause failure = mock(FoundFailureCause.class);
         when(failure.getDescription()).thenReturn(name);
         return failure;
+    }
+    
+    public BuildStateRecipe hasBadges(BadgeRecipe... badges) {
+    	List<GroovyPostbuildAction> actions = new ArrayList<GroovyPostbuildAction>();
+    	for (int i = 0; i < badges.length; i++) {
+    		actions.add(badges[i].get());
+    	}
+    	when(build.getActions(GroovyPostbuildAction.class)).thenReturn(actions);
+    	
+    	return this;
     }
 
     public BuildStateRecipe and() {

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/JobStateRecipe.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/JobStateRecipe.java
@@ -95,7 +95,7 @@ public class JobStateRecipe implements Supplier<Job<?,?>> {
 
         // pick the first build from the build history and make it the "last build"
         if (buildHistory.size() == 1) {
-            when(job.getLastBuild()).thenReturn(buildHistory.pop());
+        	doReturn(buildHistory.pop()).when(job).getLastBuild();
         }
 
         return job;

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/Sugar.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/Sugar.java
@@ -21,6 +21,10 @@ public class Sugar {
         return new BuildStateRecipe();
     }
 
+    public static BadgeRecipe badge() {
+        return new BadgeRecipe();
+    }
+
     public static <X> X a(Supplier<X> recipe) {
         return recipe.get();
     }


### PR DESCRIPTION
Hi @jan-molak 

As discussed on PR #267 I've modified the code to support only text badges from the groovy postbuild plugin.

So badges added with either:
  * addShortText(text) - puts a badge with a short text, using the default format.
  * addShortText(text, color, background, border, borderColor) - puts a badge with a short text, using the specified format.

So everything related to jelly has been removed.
I'm not great at making nice looking html/css so the badge rendering is an exact copy of the groovy postbuild plugin: a span with a style applied to it.
I suppose this is something you could improve if you want to, like adding round edges.

Please review the modifications when you have some free time.


Cheers,
Daniel
