### PR TITLE
Build Failure Analyzer: show failure name rather than description

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeDiagnosedForProblems.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeDiagnosedForProblems.java
@@ -40,7 +40,7 @@ public class CanBeDiagnosedForProblems implements Feature<CanBeDiagnosedForProbl
 
         public Problems(FailureCauseBuildAction action) {
             for (FoundFailureCause failure : action.getFoundFailureCauses()) {
-                failures.add(failure.getDescription());
+                failures.add(failure.getName());
             }
         }
 

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/BuildStateRecipe.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/BuildStateRecipe.java
@@ -192,7 +192,7 @@ public class BuildStateRecipe implements Supplier<AbstractBuild<?, ?>> {
 
     private FoundFailureCause failure(String name) {
         FoundFailureCause failure = mock(FoundFailureCause.class);
-        when(failure.getDescription()).thenReturn(name);
+        when(failure.getName()).thenReturn(name);
         return failure;
     }
 


### PR DESCRIPTION
For failures originating from jUnit test results (via the Build Failure
Analyzer plugin), the 'description' is the so-called 'stacktrace' which
typically contains details of the test failure. These details can be large,
e.g. a stack trace, a build log, or other verbose output.

As the build monitor has limited display space, use the failure name rather
than this description.

Closes #275.