### PR TITLE
Make text gender-agnostic after build is fixed again

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/headline/HeadlineOfFixed.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/headline/HeadlineOfFixed.java
@@ -36,7 +36,7 @@ public class HeadlineOfFixed implements CandidateHeadline {
 
         return Lister.describe(
                 "Back in the green!",
-                "Fixed after %s committed their changes :-)",
+                "Fixed after %s committed some changes :-)",
                 newLinkedList(committersOf(lastBuild))
         );
     }


### PR DESCRIPTION
* After a build is fixed the committer may be female/male/other so 'theirs' does not fit well