### PR TITLE
Fix #284 - Allow setting of build order

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
@@ -87,6 +87,11 @@ public class BuildMonitorView extends ListView {
     }
 
     @SuppressWarnings("unused") // used in the configure-entries.jelly form
+    public String explicitOrder() {
+        return currentConfig().getExplicitOrder();
+    }
+
+    @SuppressWarnings("unused") // used in the configure-entries.jelly form
     public boolean isDisplayCommitters() {
         return currentConfig().shouldDisplayCommitters();
     }
@@ -111,8 +116,11 @@ public class BuildMonitorView extends ListView {
 
         synchronized (this) {
 
-            String requestedOrdering = req.getParameter("order");
-            title                    = req.getParameter("title");
+            String requestedOrdering = req.getParameter("orderSelect");
+            if ("explicit".equals(req.getParameter("order"))) {
+                requestedOrdering = "ExplicitOrder";
+            }
+            title = req.getParameter("title");
 
             currentConfig().setDisplayCommitters(json.optBoolean("displayCommitters", true));
 
@@ -121,6 +129,7 @@ public class BuildMonitorView extends ListView {
             } catch (Exception e) {
                 throw new FormException("Can't order projects by " + requestedOrdering, "order");
             }
+            currentConfig().setExplicitOrder(req.getParameter("explicitOrder"));
         }
     }
 

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -2,6 +2,8 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor;
 
 import com.google.common.base.Objects;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ByName;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ExplicitOrder;
+
 import hudson.model.Job;
 
 import java.util.Comparator;
@@ -11,6 +13,8 @@ import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.functions.NullSafe
 public class Config {
 
     private boolean displayCommitters;
+    private Comparator<Job<?, ?>> order;
+    private String explicitOrder;
 
     public static Config defaultConfig() {
         return new Config();
@@ -30,6 +34,16 @@ public class Config {
 
     public void setOrder(Comparator<Job<?, ?>> order) {
         this.order = order;
+        setupForExplicit();
+    }
+
+    public String getExplicitOrder() {
+        return explicitOrder;
+    }
+
+    public void setExplicitOrder(String explicitOrder) {
+        this.explicitOrder = explicitOrder;
+        setupForExplicit();
     }
 
     public boolean shouldDisplayCommitters() {
@@ -47,7 +61,10 @@ public class Config {
                 .toString();
     }
 
-    // --
-
-    private Comparator<Job<?, ?>> order;
+    private void setupForExplicit() {
+        if (order != null && explicitOrder != null && order instanceof ExplicitOrder) {
+            ExplicitOrder explicit = (ExplicitOrder)order;
+            explicit.setExplicitOrder(explicitOrder);
+        }
+    }
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ExplicitOrder.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ExplicitOrder.java
@@ -1,0 +1,32 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+import hudson.model.Job;
+
+public class ExplicitOrder implements Comparator<Job<?, ?>> {
+    private Map<String, Integer> order;
+
+    @Override
+    public int compare(Job<?, ?> first, Job<?, ?> second) {
+        int firstOrder = Integer.MAX_VALUE;
+        int secondOrder = Integer.MAX_VALUE;
+        if (order.containsKey(first.getFullName())) {
+            firstOrder = order.get(first.getFullName());
+        }
+        if (order.containsKey(second.getFullName())) {
+            secondOrder = order.get(second.getFullName());
+        }
+        return firstOrder - secondOrder;
+    }
+
+    public void setExplicitOrder(String explicitOrder) {
+        order = new HashMap<String, Integer>();
+        String[] builds = explicitOrder.split("[ ,]+");
+        for (int i = 0; i < builds.length; i++) {
+            order.put(builds[i], i);
+        }
+    }
+}

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -57,7 +57,7 @@
   </f:entry>
 
   <f:radioBlock title="${%Sort jobs}" name="order" checked="${it.currentOrder()!='ExplicitOrder'}" value="sorted">
-    <f:entry title="${Ordered by}">
+    <f:entry title="${%Ordered by}">
       <select name="orderSelect" class="setting-input">
         <f:option value="ByName" selected='${it.currentOrder()=="ByName"}'>${%Name}</f:option>
         <f:option value="ByDisplayName" selected="${it.currentOrder()=='ByDisplayName'}">${%Display name}</f:option>

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -68,7 +68,7 @@
   </f:radioBlock>
 
   <f:radioBlock title="${%Explicit order}" name="order" checked="${it.currentOrder()=='ExplicitOrder'}" value="explicit">
-    <f:entry title="${Order of jobs:}">
+    <f:entry title="${%Order of jobs:}">
       <f:textbox name="explicitOrder" field="explicitOrder" />
     </f:entry>
   </f:radioBlock>

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -56,8 +56,8 @@
     <f:textbox name="title" value="${it.title}"/>
   </f:entry>
 
-  <f:entry title="${%Ordered by}">
-    <select name="order" class="setting-input">
+  <f:radioBlock title="${%Ordered by}" name="order" checked="${it.currentOrder()!='ExplicitOrder'}" value="sorted">
+    <select name="orderSelect" class="setting-input">
       <f:option value="ByName" selected='${it.currentOrder()=="ByName"}'>${%Name}</f:option>
       <f:option value="ByDisplayName" selected="${it.currentOrder()=='ByDisplayName'}">${%Display name}</f:option>
       <f:option value="ByFullName" selected="${it.currentOrder()=='ByFullName'}">${%Full name}</f:option>
@@ -65,7 +65,13 @@
       <f:option value="ByLastBuildTime" selected="${it.currentOrder()=='ByLastBuildTime'}">${%Last build time}</f:option>
       <f:option value="ByEstimatedDuration" selected="${it.currentOrder()=='ByEstimatedDuration'}">${%Estimated duration}</f:option>
     </select>
-  </f:entry>
+  </f:radioBlock>
+
+  <f:radioBlock title="${%Explicit order}" name="order" checked="${it.currentOrder()=='ExplicitOrder'}" value="explicit">
+    <f:entry title="${Order of jobs:}">
+      <f:textbox name="explicitOrder" field="explicitOrder" />
+    </f:entry>
+  </f:radioBlock>
 
   </f:section>
 

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -70,8 +70,8 @@
   </f:radioBlock>
 
   <f:radioBlock title="${%Specify order}" name="order" checked="${it.currentOrder()=='ExplicitOrder'}" value="explicit">
-    <f:entry title="${%Order of jobs:}">
-      <f:textbox name="explicitOrder" field="explicitOrder" />
+    <f:entry title="${%Order of jobs:}" help="${descriptor.getHelpFile('explicitOrder')}">
+      <f:textbox name="explicitOrder" field="explicitOrder" value="${it.explicitOrder()}" />
     </f:entry>
   </f:radioBlock>
 

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -56,18 +56,20 @@
     <f:textbox name="title" value="${it.title}"/>
   </f:entry>
 
-  <f:radioBlock title="${%Ordered by}" name="order" checked="${it.currentOrder()!='ExplicitOrder'}" value="sorted">
-    <select name="orderSelect" class="setting-input">
-      <f:option value="ByName" selected='${it.currentOrder()=="ByName"}'>${%Name}</f:option>
-      <f:option value="ByDisplayName" selected="${it.currentOrder()=='ByDisplayName'}">${%Display name}</f:option>
-      <f:option value="ByFullName" selected="${it.currentOrder()=='ByFullName'}">${%Full name}</f:option>
-      <f:option value="ByStatus" selected="${it.currentOrder()=='ByStatus'}">${%Status}</f:option>
-      <f:option value="ByLastBuildTime" selected="${it.currentOrder()=='ByLastBuildTime'}">${%Last build time}</f:option>
-      <f:option value="ByEstimatedDuration" selected="${it.currentOrder()=='ByEstimatedDuration'}">${%Estimated duration}</f:option>
-    </select>
+  <f:radioBlock title="${%Sort jobs}" name="order" checked="${it.currentOrder()!='ExplicitOrder'}" value="sorted">
+    <f:entry title="${Ordered by}">
+      <select name="orderSelect" class="setting-input">
+        <f:option value="ByName" selected='${it.currentOrder()=="ByName"}'>${%Name}</f:option>
+        <f:option value="ByDisplayName" selected="${it.currentOrder()=='ByDisplayName'}">${%Display name}</f:option>
+        <f:option value="ByFullName" selected="${it.currentOrder()=='ByFullName'}">${%Full name}</f:option>
+        <f:option value="ByStatus" selected="${it.currentOrder()=='ByStatus'}">${%Status}</f:option>
+        <f:option value="ByLastBuildTime" selected="${it.currentOrder()=='ByLastBuildTime'}">${%Last build time}</f:option>
+        <f:option value="ByEstimatedDuration" selected="${it.currentOrder()=='ByEstimatedDuration'}">${%Estimated duration}</f:option>
+      </select>
+    </f:entry>
   </f:radioBlock>
 
-  <f:radioBlock title="${%Explicit order}" name="order" checked="${it.currentOrder()=='ExplicitOrder'}" value="explicit">
+  <f:radioBlock title="${%Specify order}" name="order" checked="${it.currentOrder()=='ExplicitOrder'}" value="explicit">
     <f:entry title="${%Order of jobs:}">
       <f:textbox name="explicitOrder" field="explicitOrder" />
     </f:entry>

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/help-explicitOrder.html
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/help-explicitOrder.html
@@ -1,0 +1,11 @@
+<div>
+    <p>
+        You can provide a list of full job names, separated by commas and/or spaces, which will
+        be displayed in the order that their names are given. In this mode, any job which is
+        not specified, but is shown in the view, will be placed at the end.
+    </p>
+    <p>
+        Example:<br/>
+        <code>my-build, your-build, his-folder/another-build</code>
+    </p>
+</div>

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ExplicitOrderTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ExplicitOrderTest.java
@@ -1,0 +1,147 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
+
+import org.acegisecurity.AccessDeniedException;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.tasks.Publisher;
+import hudson.util.DescribableList;
+
+import static org.junit.Assert.assertTrue;
+
+public class ExplicitOrderTest {
+    @Test
+    public void separatesBySpaceOrComma() {
+        ExplicitOrder explicitOrder = new ExplicitOrder();
+        explicitOrder.setExplicitOrder("alpha,beta, gamma delta");
+        assertTrue(explicitOrder.compare(mockJob("alpha"), mockJob("beta")) < 0);
+        assertTrue(explicitOrder.compare(mockJob("alpha"), mockJob("gamma")) < 0);
+        assertTrue(explicitOrder.compare(mockJob("alpha"), mockJob("delta")) < 0);
+        assertTrue(explicitOrder.compare(mockJob("beta"), mockJob("gamma")) < 0);
+        assertTrue(explicitOrder.compare(mockJob("beta"), mockJob("delta")) < 0);
+        assertTrue(explicitOrder.compare(mockJob("gamma"), mockJob("delta")) < 0);
+    }
+
+    @Test
+    public void unlistedBuildsLast() {
+        ExplicitOrder explicitOrder = new ExplicitOrder();
+        explicitOrder.setExplicitOrder("alpha beta gamma delta");
+        assertTrue(explicitOrder.compare(mockJob("alpha"), mockJob("omega")) < 0);
+        assertTrue(explicitOrder.compare(mockJob("delta"), mockJob("omega")) < 0);
+    }
+
+    private class EmptyItemGroup implements ItemGroup<Item> {
+
+        @Override
+        public String getFullName() {
+            return "";
+        }
+
+        @Override
+        public String getFullDisplayName() {
+            return "";
+        }
+
+        @Override
+        public Collection<Item> getItems() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String getUrl() {
+            return "";
+        }
+
+        @Override
+        public String getUrlChildPrefix() {
+            return "";
+        }
+
+        @Override
+        public Item getItem(String name) throws AccessDeniedException {
+            return null;
+        }
+
+        @Override
+        public File getRootDirFor(Item child) {
+            return null;
+        }
+
+        @Override
+        public void onRenamed(Item item, String oldName, String newName) throws IOException {
+
+        }
+
+        @Override
+        public void onDeleted(Item item) throws IOException {
+
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "";
+        }
+
+        @Override
+        public File getRootDir() {
+            return null;
+        }
+
+        @Override
+        public void save() throws IOException {
+
+        }
+    }
+
+    private class MockProject extends AbstractProject<MockProject, MockBuild> {
+
+        protected MockProject(String name) {
+            super(new EmptyItemGroup(), name);
+        }
+
+        @Override
+        public DescribableList<Publisher, Descriptor<Publisher>> getPublishersList() {
+            return null;
+        }
+
+        @Override
+        protected Class<MockBuild> getBuildClass() {
+            return null;
+        }
+
+        @Override
+        public boolean isFingerprintConfigured() {
+            return false;
+        }
+
+
+    }
+
+    private class MockBuild extends AbstractBuild<MockProject, MockBuild> {
+
+        protected MockBuild(MockProject job) throws IOException {
+            super(job);
+        }
+
+        @Override
+        public void run() {
+
+        }
+
+    }
+
+    private Job<?, ?> mockJob(String fullName) {
+        Job<?, ?> mock = new MockProject(fullName);
+        return mock;
+    }
+}


### PR DESCRIPTION
This fixes #284 by allowing you to specify the order of the builds. It's not a super fancy UI, but it works. In a text field you can specify what order your builds should display in, as an alternative to sorting them by name or time or whatever.

For example, you can put `job-one, job-two, some-folder/job-three` and they will display in that given order in the view.

There are radio buttons to select between "Sort jobs" (default, old behavior) and "Specify order".