### PR TITLE
Making showing committers for fixed build configurable.

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
@@ -87,8 +87,13 @@ public class BuildMonitorView extends ListView {
     }
 
     @SuppressWarnings("unused") // used in the configure-entries.jelly form
-    public boolean isDisplayCommitters() {
-        return currentConfig().shouldDisplayCommitters();
+    public boolean isDisplayCommittersOnBuildFailure() {
+        return currentConfig().shouldDisplayCommittersOnBuildFailure();
+    }
+
+    @SuppressWarnings("unused") // used in the configure-entries.jelly form
+    public boolean isDisplayCommittersOnFixedBuild() {
+        return currentConfig().shouldDisplayCommittersOnFixedBuild();
     }
 
     private static final BuildMonitorInstallation installation = new BuildMonitorInstallation();
@@ -114,7 +119,8 @@ public class BuildMonitorView extends ListView {
             String requestedOrdering = req.getParameter("order");
             title                    = req.getParameter("title");
 
-            currentConfig().setDisplayCommitters(json.optBoolean("displayCommitters", true));
+            currentConfig().setDisplayCommittersOnBuildFailure(json.optBoolean("displayCommittersOnBuildFailure", true));
+            currentConfig().setDisplayCommittersOnFixedBuild(json.optBoolean("displayCommittersOnFixedBuild", true));
 
             try {
                 currentConfig().setOrder(orderIn(requestedOrdering));

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -10,7 +10,8 @@ import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.functions.NullSafe
 
 public class Config {
 
-    private boolean displayCommitters;
+    private boolean displayCommittersOnBuildFailure;
+    private boolean displayCommittersOnFixedBuild;
 
     public static Config defaultConfig() {
         return new Config();
@@ -32,12 +33,20 @@ public class Config {
         this.order = order;
     }
 
-    public boolean shouldDisplayCommitters() {
-        return getOrElse(displayCommitters, true);
+    public boolean shouldDisplayCommittersOnBuildFailure() {
+        return getOrElse(displayCommittersOnBuildFailure, true);
     }
 
-    public void setDisplayCommitters(boolean flag) {
-        this.displayCommitters = flag;
+    public void setDisplayCommittersOnBuildFailure(boolean flag) {
+        this.displayCommittersOnBuildFailure = flag;
+    }
+
+    public boolean shouldDisplayCommittersOnFixedBuild() {
+        return getOrElse(displayCommittersOnFixedBuild, false);
+    }
+
+    public void setDisplayCommittersOnFixedBuild(boolean flag) {
+        this.displayCommittersOnFixedBuild = flag;
     }
 
     @Override

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViews.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViews.java
@@ -31,7 +31,7 @@ public class JobViews {
         List<Feature> viewFeatures = newArrayList();
 
         // todo: a more elegant way of assembling the features would be nice
-        viewFeatures.add(new HasHeadline(new HeadlineConfig(config.shouldDisplayCommitters())));
+        viewFeatures.add(new HasHeadline(new HeadlineConfig(config.shouldDisplayCommittersOnBuildFailure(), config.shouldDisplayCommittersOnFixedBuild())));
         viewFeatures.add(new KnowsLastCompletedBuildDetails());
         viewFeatures.add(new KnowsCurrentBuildsDetails());
 

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/headline/HeadlineConfig.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/headline/HeadlineConfig.java
@@ -4,9 +4,12 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features.headl
  * @author Jan Molak
  */
 public class HeadlineConfig {
-    public final boolean displayCommitters;
+    public final boolean displayCommittersOnBuildFailure;
+    public final boolean displayCommittersOnFixedBuild;
 
-    public HeadlineConfig(boolean displayCommitters) {
-        this.displayCommitters = displayCommitters;
+    public HeadlineConfig(boolean displayCommittersOnBuildFailure, boolean displayCommittersOnFixedBuild) {
+
+        this.displayCommittersOnBuildFailure = displayCommittersOnBuildFailure;
+        this.displayCommittersOnFixedBuild = displayCommittersOnFixedBuild;
     }
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/headline/HeadlineOfAborted.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/headline/HeadlineOfAborted.java
@@ -35,7 +35,7 @@ public class HeadlineOfAborted implements CandidateHeadline {
     private String text(BuildViewModel build) {
         Optional<InterruptedBuildAction> interruption = build.detailsOf(InterruptedBuildAction.class);
 
-        if (config.displayCommitters && interruption.isPresent()) {
+        if (config.displayCommittersOnBuildFailure && interruption.isPresent()) {
 
             Optional<String> username = userResponsibleFor(interruption.get());
 

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/headline/HeadlineOfExecuting.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/headline/HeadlineOfExecuting.java
@@ -37,7 +37,7 @@ public class HeadlineOfExecuting implements CandidateHeadline {
     }
 
     private Set<String> committersOf(BuildViewModel build) {
-        return config.displayCommitters
+        return config.displayCommittersOnBuildFailure
                 ? build.committers()
                 : Sets.<String>newHashSet();
     }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/headline/HeadlineOfFailing.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/headline/HeadlineOfFailing.java
@@ -80,7 +80,7 @@ public class HeadlineOfFailing implements CandidateHeadline {
     }
 
     private Set<String> responsibleFor(BuildViewModel build) {
-        return config.displayCommitters
+        return config.displayCommittersOnBuildFailure
                 ? build.culprits()
                 : Sets.<String>newHashSet();
     }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/headline/HeadlineOfFixed.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/headline/HeadlineOfFixed.java
@@ -24,7 +24,7 @@ public class HeadlineOfFixed implements CandidateHeadline {
 
     @Override
     public boolean isApplicableTo(JobView job) {
-        return didTheJobJustGetFixedWith(job.lastCompletedBuild());
+        return didTheJobJustGetFixedWith(job.lastCompletedBuild()) && config.displayCommittersOnFixedBuild;
     }
 
     @Override
@@ -35,7 +35,7 @@ public class HeadlineOfFixed implements CandidateHeadline {
     private String textFor(BuildViewModel lastBuild) {
 
         return Lister.describe(
-                "Back in the green!",
+                "",
                 "Fixed after %s committed their changes :-)",
                 newLinkedList(committersOf(lastBuild))
         );
@@ -51,7 +51,7 @@ public class HeadlineOfFixed implements CandidateHeadline {
     }
 
     private Set<String> committersOf(BuildViewModel build) {
-        return config.displayCommitters
+        return config.displayCommittersOnFixedBuild
                 ? build.committers()
                 : Sets.<String>newHashSet();
     }

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -71,8 +71,12 @@
 
   <f:section title="${%Build Monitor - Widget Settings}">
 
-    <f:entry title="${%Display committers}" help="${descriptor.getHelpFile('displayCommitters')}">
-      <f:checkbox id="displayCommitters" field="displayCommitters" />
+    <f:entry title="${%Display committers on build failure}" help="${descriptor.getHelpFile('displayCommitters')}">
+      <f:checkbox id="displayCommittersOnBuildFailure" field="displayCommittersOnBuildFailure" />
+    </f:entry>
+
+    <f:entry title="${%Display committers on build fix}"}">
+          <f:checkbox id="displayCommittersOnFixedBuild" field="displayCommittersOnFixedBuild" />
     </f:entry>
 
   </f:section>

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/help-displayCommitters.html
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/help-displayCommitters.html
@@ -5,10 +5,6 @@
         and need help fixing it.
     </p>
     <p>
-        This feature works the other way around too! If someone fixes a broken build,
-        it's their identifier that gets to appear on the screen.
-    </p>
-    <p>
         <strong>Did you know</strong> that when a broken build is
         <a href="https://wiki.jenkins-ci.org/display/JENKINS/Claim+plugin" target="_blank">claimed</a>,
         Build Monitor will show who's fixing it instead of who might have broken it?

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugin/assetbundler/PathToAssetTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugin/assetbundler/PathToAssetTest.java
@@ -7,8 +7,7 @@ import org.junit.rules.ExpectedException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static junit.framework.TestCase.assertTrue;
 
 public class PathToAssetTest {
 
@@ -17,8 +16,10 @@ public class PathToAssetTest {
         URL base = baseResourceUrlGivenByJenkins("file:///opt/jenkins/plugins/build-monitor-plugin/");
 
         PathToAsset path = new PathToAsset(base, "less/index.less");
-
-        assertThat(absolute(path), is("/opt/jenkins/plugins/build-monitor-plugin/less/index.less"));
+        //Tweaking it to be able to run on Windows
+        String actualValue = absolute(path).replace("\\", "/");
+        String expectedValue = "/opt/jenkins/plugins/build-monitor-plugin/less/index.less";
+        assertTrue("\nActual: " + actualValue + " \n does not contain expected value : " + expectedValue, actualValue.contains(expectedValue));
     }
 
     @Test
@@ -26,8 +27,10 @@ public class PathToAssetTest {
         URL base = baseResourceUrlGivenByJenkins("file://server/jenkins/plugins/build-monitor-plugin/");
 
         PathToAsset path = new PathToAsset(base, "less/index.less");
-
-        assertThat(absolute(path), is("/server/jenkins/plugins/build-monitor-plugin/less/index.less"));
+        //Tweaking it to be able to run on Windows
+        String actualValue = absolute(path).replace("\\", "/");
+        String expectedValue = "/server/jenkins/plugins/build-monitor-plugin/less/index.less";
+        assertTrue("\nActual: " + actualValue + " \n does not contain expected value : " + expectedValue, actualValue.contains(expectedValue));
     }
 
     @Rule public ExpectedException thrown = ExpectedException.none();

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingAbortedBuildDetails.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingAbortedBuildDetails.java
@@ -38,11 +38,11 @@ public class HasHeadlineShowingAbortedBuildDetails {
     // --
 
     private Feature hasHeadlineThatShowsCommitters() {
-        return new HasHeadline(new HeadlineConfig(true));
+        return new HasHeadline(new HeadlineConfig(true, false));
     }
 
     private Feature hasHeadlineThatDoesNotShowCommitters() {
-        return new HasHeadline(new HeadlineConfig(false));
+        return new HasHeadline(new HeadlineConfig(false, false));
     }
 
     private String headlineOf(JobView job) {

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingFailedBuildDetailsTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingFailedBuildDetailsTest.java
@@ -81,11 +81,11 @@ public class HasHeadlineShowingFailedBuildDetailsTest {
     // --
 
     private Feature hasHeadlineThatShowsCommitters() {
-        return new HasHeadline(new HeadlineConfig(true));
+        return new HasHeadline(new HeadlineConfig(true, false));
     }
 
     private Feature hasHeadlineThatDoesNotShowCommitters() {
-        return new HasHeadline(new HeadlineConfig(false));
+        return new HasHeadline(new HeadlineConfig(false, false));
     }
 
     private String headlineOf(JobView job) {

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingFixedBuildDetailsTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingFixedBuildDetailsTest.java
@@ -37,7 +37,7 @@ public class HasHeadlineShowingFixedBuildDetailsTest {
                 a(job().whereTheLast(build().succeededThanksTo()).
                         andThePrevious(build().wasBrokenBy("Daniel", "Ben")))));
 
-        assertThat(headlineOf(view), is("Back in the green!"));
+        assertThat(headlineOf(view), is(""));
     }
 
     @Test
@@ -46,7 +46,7 @@ public class HasHeadlineShowingFixedBuildDetailsTest {
                 a(job().whereTheLast(build().succeededThanksTo("Adam")).
                         andThePrevious(build().wasBrokenBy("Daniel", "Ben")))));
 
-        assertThat(headlineOf(view), is("Back in the green!"));
+        assertThat(headlineOf(view), is(""));
     }
 
     @Test
@@ -69,11 +69,11 @@ public class HasHeadlineShowingFixedBuildDetailsTest {
     // --
 
     private Feature hasHeadlineThatShowsCommitters() {
-        return new HasHeadline(new HeadlineConfig(true));
+        return new HasHeadline(new HeadlineConfig(true, true));
     }
 
     private Feature hasHeadlineThatDoesNotShowCommitters() {
-        return new HasHeadline(new HeadlineConfig(false));
+        return new HasHeadline(new HeadlineConfig(false, false));
     }
 
     private String headlineOf(JobView job) {

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingRunningBuildDetailsTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingRunningBuildDetailsTest.java
@@ -49,11 +49,11 @@ public class HasHeadlineShowingRunningBuildDetailsTest {
     // --
 
     private Feature hasHeadlineThatShowsCommitters() {
-        return new HasHeadline(new HeadlineConfig(true));
+        return new HasHeadline(new HeadlineConfig(true, false));
     }
 
     private Feature hasHeadlineThatDoesNotShowCommitters() {
-        return new HasHeadline(new HeadlineConfig(false));
+        return new HasHeadline(new HeadlineConfig(false, false));
     }
 
     private String headlineOf(JobView job) {

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineWhichShowsNothingTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineWhichShowsNothingTest.java
@@ -22,7 +22,7 @@ public class HasHeadlineWhichShowsNothingTest {
     // --
 
     private Feature hasHeadlineThatShowsCommitters() {
-        return new HasHeadline(new HeadlineConfig(true));
+        return new HasHeadline(new HeadlineConfig(true, false));
     }
 
     private String headlineOf(JobView job) {


### PR DESCRIPTION
Changes in this pull request -
1. The name of the person who fixed the build stays on until the next successful check-in. This is not always desirable and adds a lot of noise on the monitor. This is now configurable in settings.
2. "Back in green" does not convey much specially when build is triggered manually. Got rid of it.
3. Some unit tests were not running well in Windows, refactored a bit to make it work on Windows.