### PR TITLE
Changed floor of Text scale to 0.1

### DIFF
--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
@@ -14,7 +14,7 @@
                 </li>
                 <li class="settings-option">
                     <span class="slider-label">Text scale</span>
-                    <rzslider rz-slider-model="settings.fontSize" rz-slider-options="{ floor: 0.3, ceil: 2, step: 0.1, precision: 1 }"></rzslider>
+                    <rzslider rz-slider-model="settings.fontSize" rz-slider-options="{ floor: 0.1, ceil: 2, step: 0.1, precision: 1 }"></rzslider>
                 </li>
                 <li class="settings-option">
                     <span class="slider-label">Maximum number of columns</span>


### PR DESCRIPTION
The reason for that is I have a build monitor setup with only one job but long HTML description and I need a smaller font to fit all on the screen. See screenshot, column headers are out of screen:

![image](https://user-images.githubusercontent.com/2153370/26964424-acd6c49a-4cf1-11e7-960d-aaee0ad1342a.png)

