### PR TITLE
The displayed failure cause can now be configured

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
@@ -85,6 +85,11 @@ public class BuildMonitorView extends ListView {
     public String currentOrder() {
         return currentConfig().getOrder().getClass().getSimpleName();
     }
+    
+    @SuppressWarnings("unused") // used in the configure-entries.jelly form
+    public String currentbuildFailureAnalyzerDisplayedField() {
+        return currentConfig().getBuildFailureAnalyzerDisplayedField().getValue();
+    }
 
     @SuppressWarnings("unused") // used in the configure-entries.jelly form
     public boolean isDisplayCommitters() {
@@ -115,7 +120,8 @@ public class BuildMonitorView extends ListView {
             title                    = req.getParameter("title");
 
             currentConfig().setDisplayCommitters(json.optBoolean("displayCommitters", true));
-
+            currentConfig().setBuildFailureAnalyzerDisplayedField(req.getParameter("buildFailureAnalyzerDisplayedField"));
+            
             try {
                 currentConfig().setOrder(orderIn(requestedOrdering));
             } catch (Exception e) {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -11,7 +11,8 @@ import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.functions.NullSafe
 public class Config {
 
     private boolean displayCommitters;
-
+    private BuildFailureAnalyzerDisplayedField buildFailureAnalyzerDisplayedField;
+    
     public static Config defaultConfig() {
         return new Config();
     }
@@ -31,7 +32,15 @@ public class Config {
     public void setOrder(Comparator<Job<?, ?>> order) {
         this.order = order;
     }
-
+    
+    public BuildFailureAnalyzerDisplayedField getBuildFailureAnalyzerDisplayedField() {
+        return getOrElse(buildFailureAnalyzerDisplayedField, BuildFailureAnalyzerDisplayedField.Name);
+    }
+    
+    public void setBuildFailureAnalyzerDisplayedField(String buildFailureAnalyzerDisplayedField) {
+        this.buildFailureAnalyzerDisplayedField = BuildFailureAnalyzerDisplayedField.valueOf(buildFailureAnalyzerDisplayedField);
+    }
+    
     public boolean shouldDisplayCommitters() {
         return getOrElse(displayCommitters, true);
     }
@@ -39,7 +48,7 @@ public class Config {
     public void setDisplayCommitters(boolean flag) {
         this.displayCommitters = flag;
     }
-
+    
     @Override
     public String toString() {
         return Objects.toStringHelper(this)
@@ -49,5 +58,21 @@ public class Config {
 
     // --
 
+    public enum BuildFailureAnalyzerDisplayedField {
+        Name("name"),
+        Description("description"),
+        None("none");
+    
+        private final String value;
+        BuildFailureAnalyzerDisplayedField(String value) {
+            this.value = value;
+        }
+    
+        public String getValue() { return value; }
+    
+        @Override
+        public String toString() { return value; }
+    }
+    
     private Comparator<Job<?, ?>> order;
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViews.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViews.java
@@ -40,7 +40,7 @@ public class JobViews {
         }
 
         if (jenkins.hasPlugin(Build_Failure_Analyzer)) {
-            viewFeatures.add(new CanBeDiagnosedForProblems());
+            viewFeatures.add(new CanBeDiagnosedForProblems(config.getBuildFailureAnalyzerDisplayedField()));
         }
 
         if (jenkins.hasPlugin(Groovy_Post_Build)) {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeDiagnosedForProblems.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeDiagnosedForProblems.java
@@ -2,6 +2,7 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.Config.BuildFailureAnalyzerDisplayedField;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
 import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
@@ -13,11 +14,12 @@ import static com.google.common.collect.Lists.newArrayList;
 
 public class CanBeDiagnosedForProblems implements Feature<CanBeDiagnosedForProblems.Problems> {
     private JobView job;
-
-    public CanBeDiagnosedForProblems() {
-
+    private BuildFailureAnalyzerDisplayedField displayedField;
+    
+    public CanBeDiagnosedForProblems(BuildFailureAnalyzerDisplayedField displayedField) {
+        this.displayedField = displayedField;
     }
-
+    
     @Override
     public CanBeDiagnosedForProblems of(JobView jobView) {
         this.job = jobView;
@@ -30,17 +32,19 @@ public class CanBeDiagnosedForProblems implements Feature<CanBeDiagnosedForProbl
         Optional<FailureCauseBuildAction> details = job.lastCompletedBuild().detailsOf(FailureCauseBuildAction.class);
 
         return details.isPresent()                  // would be nice to have .map(Claim(_)).orElse(), but hey...
-                ? new Problems(details.get())
+                ? new Problems(details.get(), displayedField)
                 : null;                             // `null` because we don't want to serialise an empty object
     }
-
+    
     public static class Problems {
 
         private final List<String> failures = newArrayList();
 
-        public Problems(FailureCauseBuildAction action) {
+        public Problems(FailureCauseBuildAction action, BuildFailureAnalyzerDisplayedField displayedField) {
             for (FoundFailureCause failure : action.getFoundFailureCauses()) {
-                failures.add(failure.getName());
+                if (displayedField != BuildFailureAnalyzerDisplayedField.None) {
+                    failures.add(displayedField == BuildFailureAnalyzerDisplayedField.Description ? failure.getDescription() : failure.getName());
+                }
             }
         }
 

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -74,6 +74,14 @@
     <f:entry title="${%Display committers}" help="${descriptor.getHelpFile('displayCommitters')}">
       <f:checkbox id="displayCommitters" field="displayCommitters" />
     </f:entry>
+    
+    <f:entry title="${%Failure Analyzer Plugin: Field to display}" help="${descriptor.getHelpFile('buildFailureAnalyzerDisplayedField')}">
+          <select name="buildFailureAnalyzerDisplayedField" class="setting-input">
+			<f:option value="Name" selected="${it.currentbuildFailureAnalyzerDisplayedField()=='Name'}">${%Name}</f:option>
+			<f:option value="Description" selected="${it.currentbuildFailureAnalyzerDisplayedField()=='Description'}">${%Description}</f:option>
+			<f:option value="None" selected="${it.currentbuildFailureAnalyzerDisplayedField()=='None'}">${%None}</f:option>
+          </select>
+        </f:entry>
 
   </f:section>
 

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/help-buildFailureAnalyzerDisplayedField.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/help-buildFailureAnalyzerDisplayedField.jelly
@@ -1,0 +1,9 @@
+<div>
+    <p>
+        If you use the Build Failure Analyzer Plugin you have the option to display either the 'name' or the
+        'description' field of the failure cause or display it not at all.
+    </p>
+    <p>
+        By default the 'name' field will be displayed.
+    </p>
+</div>

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeDiagnosedForProblemsTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeDiagnosedForProblemsTest.java
@@ -1,5 +1,6 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
 
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.Config.BuildFailureAnalyzerDisplayedField;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
 import org.junit.Test;
 
@@ -16,7 +17,7 @@ public class CanBeDiagnosedForProblemsTest {
     public void should_describe_known_problems() {
         String rogueAi = "Pod bay doors didn't open";
 
-        job = a(jobView().which(new CanBeDiagnosedForProblems()).of(
+        job = a(jobView().which(new CanBeDiagnosedForProblems(BuildFailureAnalyzerDisplayedField.Name)).of(
                 a(job().whereTheLast(build().finishedWith(FAILURE).and().knownProblems(rogueAi)))));
 
         assertThat(diagnosedFailuresOf(job).value(), hasItem(rogueAi));


### PR DESCRIPTION
Hi!

We are using this plugin at my company quite extensively, thanks for developing it!
We had one issue with it, which I try to address in this PR:

If the Build Failure Analyzer plugin is also present, the found failure causes are displayed in the Build View.
Currently always the name will be shown, which is suboptimal, as sometimes the description field is more sensible (The name field can't include extracted data from the build log, while the description can).

In order to mitigate this, I made the field configurable (include a 'name', 'description', and 'none' option)

It would be great if you could review the  changes and suggest addition/changes in order to get this into the plugin itself. This first version of the PR might be still a bit rough at the edges, I am very open to criticism. :)

Testing for me sadly was a bit of a hassle as I am on a Windows machine and the tetsing setup does not work 100% there (Tests in PathToAssetTest are failing).

This PR is supposed to fix https://github.com/jan-molak/jenkins-build-monitor-plugin/issues/310 and to implement https://waffle.io/jan-molak/jenkins-build-monitor-plugin/cards/58ad6d1789971d7300ae472b