### PR TITLE
Fix Windows Build Error

### DIFF
--- a/build-monitor-plugin/pom.xml
+++ b/build-monitor-plugin/pom.xml
@@ -302,7 +302,7 @@
                         </goals>
                         <configuration>
                             <outputTemplate>version={{ version }}</outputTemplate>
-                            <outputUri>file://${project.basedir}/target/classes/build-monitor.properties</outputUri>
+                            <outputUri>${project.baseUri}/target/classes/build-monitor.properties</outputUri>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Using the Apache Maven Release Plugin 'version' goal requires a Uri, but ${project.outputUri} is null and ${project.basedir} is a UNC path on Windows.
Using Apache Maven Resources Plugin works cross platform.

For more information, see:
https://github.com/smartcodeltd/release-candidate-maven-plugin/issues/6
https://github.com/smartcodeltd/release-candidate-maven-plugin/pull/7