### PR TITLE
If there are no identified failure causes, the failure cause line is now hidden altogether on the Build Monitor

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeDiagnosedForProblems.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeDiagnosedForProblems.java
@@ -41,8 +41,8 @@ public class CanBeDiagnosedForProblems implements Feature<CanBeDiagnosedForProbl
         private final List<String> failures = newArrayList();
 
         public Problems(FailureCauseBuildAction action, BuildFailureAnalyzerDisplayedField displayedField) {
-            for (FoundFailureCause failure : action.getFoundFailureCauses()) {
-                if (displayedField != BuildFailureAnalyzerDisplayedField.None) {
+            if (displayedField != BuildFailureAnalyzerDisplayedField.None) {
+                for (FoundFailureCause failure : action.getFoundFailureCauses()) {
                     failures.add(displayedField == BuildFailureAnalyzerDisplayedField.Description ? failure.getDescription() : failure.getName());
                 }
             }

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/widgets.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/widgets.jelly
@@ -26,7 +26,7 @@
                 <li data-ng-show="!! project.lastCompletedBuild.description" class="build-description description-setter-plugin"
                     ng-bind-html="project.lastCompletedBuild.description" />
                 <li data-ng-show="!! project.claim.active" class="claim-plugin">Claimed by <strong>{{ project.claim.author }}</strong>: {{ project.claim.reason }}</li>
-                <li data-ng-show="!! project.problems" class="build-failure-analyzer-plugin possible-failure-cause">
+                <li data-ng-show="!! project.problems &amp;&amp; project.problems.length > 0" class="build-failure-analyzer-plugin possible-failure-cause">
                     <span>
                         <ng-pluralize
                             count="project.problems.length"


### PR DESCRIPTION
Currently when both the Build Monitor Plugin and the Build Failure Analyzer Plugin are set up in Jenkins and there are no identified failure causes the BM Plugin will show '0 identified problems:' in the BM widget, which is superfluous.

This PR removes the line altogether if it there are no found failure causes.

This PR extends PR https://github.com/jan-molak/jenkins-build-monitor-plugin/pull/324).

Cheers
Jan-Fabian