### PR TITLE
The failure analyzer plugin field to display setting is not reset by accident when opening the view settings

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
@@ -87,7 +87,7 @@ public class BuildMonitorView extends ListView {
     }
     
     @SuppressWarnings("unused") // used in the configure-entries.jelly form
-    public String currentbuildFailureAnalyzerDisplayedField() {
+    public String currentBuildFailureAnalyzerDisplayedField() {
         return currentConfig().getBuildFailureAnalyzerDisplayedField().getValue();
     }
 

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -59,9 +59,9 @@ public class Config {
     // --
 
     public enum BuildFailureAnalyzerDisplayedField {
-        Name("name"),
-        Description("description"),
-        None("none");
+        Name("Name"),
+        Description("Description"),
+        None("None");
     
         private final String value;
         BuildFailureAnalyzerDisplayedField(String value) {

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -77,9 +77,9 @@
     
     <f:entry title="${%Failure Analyzer Plugin: Field to display}" help="${descriptor.getHelpFile('buildFailureAnalyzerDisplayedField')}">
           <select name="buildFailureAnalyzerDisplayedField" class="setting-input">
-			<f:option value="Name" selected="${it.currentbuildFailureAnalyzerDisplayedField()=='Name'}">${%Name}</f:option>
-			<f:option value="Description" selected="${it.currentbuildFailureAnalyzerDisplayedField()=='Description'}">${%Description}</f:option>
-			<f:option value="None" selected="${it.currentbuildFailureAnalyzerDisplayedField()=='None'}">${%None}</f:option>
+			<f:option value="Name" selected="${it.currentBuildFailureAnalyzerDisplayedField()=='Name'}">${%Name}</f:option>
+			<f:option value="Description" selected="${it.currentBuildFailureAnalyzerDisplayedField()=='Description'}">${%Description}</f:option>
+			<f:option value="None" selected="${it.currentBuildFailureAnalyzerDisplayedField()=='None'}">${%None}</f:option>
           </select>
         </f:entry>
 


### PR DESCRIPTION
Due to mistake in https://github.com/jan-molak/jenkins-build-monitor-plugin/commit/0736edc80fb1ffe4562aac86332e10ded81e9d11 the "Failure Analyzer Plugin: Field to display" setting was always reset to "Name" when opening the settings of a view. Due to that the setting would get lost when the user then saves the settings without reverting this unwanted change.

This PR fixes that bug.