### PR TITLE
Fix for issue #332

### DIFF
--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/utils/CommandLineTools.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/utils/CommandLineTools.java
@@ -8,11 +8,19 @@ import static net.serenitybdd.integration.utils.Nulls.coalesce;
 
 public class CommandLineTools {
     public static Path java() {
-        Path javaBin = Paths.get(coalesce(
+        Path javaHome = Paths.get(coalesce(
                 System.getenv("JENKINS_JAVA_HOME"),
                 System.getenv("JAVA_HOME"),
                 System.getProperty("java.home")
-        )).resolve("bin/java");
+        ));
+        
+        Path javaBin = null;
+        if (Files.exists(javaHome.resolve("bin/java"))) {
+        	javaBin = javaHome.resolve("bin/java");
+        }
+        else if (Files.exists(javaHome.resolve("bin/java.exe"))) {
+        	javaBin = javaHome.resolve("bin/java.exe");
+        }
 
         if (! Files.isExecutable(javaBin)) {
             throw new RuntimeException("'java' executable not found. Please set the JAVA_HOME env variable to point to your Java home directory.");


### PR DESCRIPTION
When running acceptance tests on Windows, you must specify "java.exe"
instead of "java" in the Path.resolve(...) call.