### PR TITLE
Avoided repeating stage name when multiple executions are running in parallel

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/pipeline/BreadthFirstNodeTraversal.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/pipeline/BreadthFirstNodeTraversal.java
@@ -2,18 +2,20 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.pipeline;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 
 public abstract class BreadthFirstNodeTraversal<N> {
 
     private final Queue<N> nodesToAccess;
-    private final List<String> stages;
+    private final Set<String> stages;
 
     public BreadthFirstNodeTraversal() {
         this.nodesToAccess = new LinkedList<N>();
-        this.stages = new ArrayList<String>();
+        this.stages = new LinkedHashSet<String>();
     }
 
     public void start(List<N> nodes) {
@@ -35,6 +37,6 @@ public abstract class BreadthFirstNodeTraversal<N> {
     protected abstract Collection<N> getParents(N node);
 
     public List<String> getStages() {
-        return stages;
+        return new ArrayList<String>(stages);
     }
 }

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/pipeline/BreadthFirstNodeTraversalTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/pipeline/BreadthFirstNodeTraversalTest.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
@@ -22,13 +23,26 @@ public class BreadthFirstNodeTraversalTest {
                         withParent(normalNode("C4")))),
                 withParent(normalNode("B3")));
 
-        BreadthFirstNodeTraversal<TestNode> traversal = new BreadthFirstTestNodeTraversal();
-
-        traversal.start(Collections.singletonList(head));
-
-        List<String> stages = traversal.getStages();
+        List<String> stages = findStages(head);
 
         assertThat(stages, containsInAnyOrder("B1", "B2"));
+    }
+
+    @Test
+    public void stages_should_not_be_repeated() {
+        TestNode head = normalNode("A1",
+                withParent(stageNode("B1")),
+                withParent(stageNode("B1")));
+
+        List<String> stages = findStages(head);
+
+        assertThat(stages, contains("B1"));
+    }
+
+    private List<String> findStages(TestNode head) {
+        BreadthFirstNodeTraversal<TestNode> traversal = new BreadthFirstTestNodeTraversal();
+        traversal.start(Collections.singletonList(head));
+        return traversal.getStages();
     }
 
     private enum Type {


### PR DESCRIPTION
Should fix #329.