### PR TITLE
Multiconfiguration Job Support - Extends "features mixins"

### DIFF
--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/ProjectWidget.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/ProjectWidget.java
@@ -37,5 +37,9 @@ public class ProjectWidget {
         this.projectOfInterest = projectOfInterest;
     }
 
+    public Question<String> multiConfigBadgeNames() {
+        return new ProjectMultiConfigWidget();
+    }
+
     private final String projectOfInterest;
 }

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/project_widget/ProjectMultiConfigWidget.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/project_widget/ProjectMultiConfigWidget.java
@@ -1,0 +1,18 @@
+package com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.project_widget;
+
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.user_interface.BuildMonitorDashboard;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Question;
+import net.serenitybdd.screenplay.questions.Text;
+import net.serenitybdd.screenplay.targets.Target;
+
+public class ProjectMultiConfigWidget implements Question<String> {
+
+    @Override
+    public String answeredBy(Actor actor) {
+        Target multiConfigBadge1    = BuildMonitorDashboard.Multi_Config_1;
+        Target multiConfigBadge2    = BuildMonitorDashboard.Multi_Config_2;
+
+        return Text.of(multiConfigBadge1).viewedBy(actor).resolve() + ":::" + Text.of(multiConfigBadge2).viewedBy(actor).resolve();
+    }
+}

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/configuration/DisplayMultiConfig.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/configuration/DisplayMultiConfig.java
@@ -1,0 +1,23 @@
+package com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.configuration;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplay.jenkins.actions.Choose;
+import net.serenitybdd.screenplay.jenkins.user_interface.ViewConfigurationPage;
+import net.thucydides.core.annotations.Step;
+
+import static net.serenitybdd.screenplay.Tasks.instrumented;
+
+public class DisplayMultiConfig implements Task{
+
+    public static Task usingDisplayMultiConfigCheckbox() {
+        return instrumented(DisplayMultiConfig.class);
+    }
+
+    @Step("{0} clicks the Display Multi-Config Jobs checkbox")
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        actor.attemptsTo(
+                Choose.the(ViewConfigurationPage.Display_Multi_Config_Jobs)
+        );
+    }
+}

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/user_interface/BuildMonitorDashboard.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/user_interface/BuildMonitorDashboard.java
@@ -11,6 +11,9 @@ public class BuildMonitorDashboard {
     public static final Target Project_Widget_Badges          = Target.the("Project Widget Badges").locatedBy("//li[header/h2[.='{0}']]//*[@class='badges']");
     public static final Target Project_Widget_Pipeline_Stages = Target.the("Project Widget Builds").locatedBy("//li[header/h2[.='{0}']]//*[contains(@class, 'build-stages')]");
 
+    public static final Target Multi_Config_1                 = Target.the("Multi Config Badge One").locatedBy("//*[@id='multiproject-1']/header/h2/a");
+    public static final Target Multi_Config_2                 = Target.the("Multi Config Badge Two").locatedBy("//*[@id='multiproject-2']/header/h2/a");
+
     public static final Target Control_Panel = Target.the("Control Panel").locatedBy("//label[@for='settings-toggle']");
     public static final Target Show_Badges = Target.the("Show Badges Toggle").locatedBy("//input[@id='settings-show-badges']");
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/HaveAMultiConfigProjectCreated.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/HaveAMultiConfigProjectCreated.java
@@ -1,0 +1,43 @@
+package net.serenitybdd.screenplay.jenkins;
+
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplay.actions.Click;
+import net.serenitybdd.screenplay.jenkins.tasks.CreateAMultiConfigurationProject;
+import net.serenitybdd.screenplay.jenkins.tasks.configuration.TodoList;
+import net.thucydides.core.annotations.Step;
+
+import static net.serenitybdd.screenplay.Tasks.instrumented;
+import static net.serenitybdd.screenplay.jenkins.user_interface.navigation.SidePanel.Back_to_Dashboard;
+
+public class HaveAMultiConfigProjectCreated implements Task{
+
+    public static HaveAMultiConfigProjectCreated called(String name) {
+        return instrumented(HaveAMultiConfigProjectCreated.class, name);
+    }
+
+    public Task andConfigureItTo(Task... configurationTasks) {
+        this.requiredConfiguration.addAll(configurationTasks);
+
+        return this;
+    }
+
+    @Step("{0} creates the '#projectName' pipeline")
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        actor.attemptsTo(
+                CreateAMultiConfigurationProject.called(projectName)
+                    .andConfigureItTo(requiredConfiguration),
+                    Click.on(Back_to_Dashboard)
+        );
+    }
+
+    public HaveAMultiConfigProjectCreated (String projectName) {
+        this.projectName = projectName;
+    }
+
+
+    private final String projectName;
+    private final TodoList requiredConfiguration = TodoList.empty();
+}

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/CreateAMultiConfigurationProject.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/CreateAMultiConfigurationProject.java
@@ -1,0 +1,41 @@
+package net.serenitybdd.screenplay.jenkins.tasks;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplay.jenkins.tasks.configuration.AddAxis;
+import net.serenitybdd.screenplay.jenkins.tasks.configuration.TodoList;
+import net.serenitybdd.screenplay.jenkins.user_interface.NewJobPage;
+import net.thucydides.core.annotations.Step;
+
+import static net.serenitybdd.screenplay.Tasks.instrumented;
+
+public class CreateAMultiConfigurationProject implements Task {
+
+    public static CreateAMultiConfigurationProject called(String name) {
+        return instrumented(CreateAMultiConfigurationProject.class, name);
+    }
+
+    public CreateAMultiConfigurationProject andConfigureItTo(Task configurationTask) {
+        this.configureTheProject.add(configurationTask);
+
+        return this;
+    }
+
+    @Step("{0} creates a 'Multi-Configuration' called '#name'")
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        actor.attemptsTo(
+                CreateAProject.called(name)
+                    .ofType(NewJobPage.Multi_Configuration_Project)
+                    .andConfigureItTo(configureTheProject)
+        );
+    }
+
+    public CreateAMultiConfigurationProject(String jobName) {
+        this.name = jobName;
+    }
+
+    private final String name;
+    private final TodoList configureTheProject = TodoList.empty();
+
+}

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/CreateAProject.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/CreateAProject.java
@@ -48,7 +48,7 @@ class CreateAProject implements Task {
         this.name = jobName;
     }
 
-    private final String   name;
-    private final TodoList configureTheProject = TodoList.empty();
-    private       Target projectType;
+    private final String    name;
+    private final TodoList  configureTheProject = TodoList.empty();
+    private       Target    projectType;
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/AddAxis.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/AddAxis.java
@@ -1,0 +1,35 @@
+package net.serenitybdd.screenplay.jenkins.tasks.configuration;
+
+import net.serenitybdd.screenplay.actions.Click;
+import net.serenitybdd.screenplay.actions.Enter;
+import net.serenitybdd.screenplay.jenkins.targets.Link;
+import net.serenitybdd.screenplay.jenkins.user_interface.ProjectConfigurationPage;
+import net.serenitybdd.screenplay.jenkins.user_interface.EditUserDefinedAxis;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplayx.actions.Scroll;
+import net.thucydides.core.annotations.Step;
+
+public class AddAxis implements Task {
+    public static Task of(Axis axis) {
+        return new AddAxis(axis);
+    }
+
+    @Step("{0} configures Multi-Configuration project axis")
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        actor.attemptsTo(
+                Scroll.to(ProjectConfigurationPage.Add_Axis),
+                Click.on(ProjectConfigurationPage.Add_Axis),
+                Click.on(Link.called("User-defined Axis")),
+                Enter.theValue(axis.getName()).into(EditUserDefinedAxis.EditAxisName),
+                Enter.theValue(axis.getValues()).into(EditUserDefinedAxis.EditAxisVals)
+        );
+    }
+
+    public AddAxis(Axis axis) {
+        this.axis = axis;
+    }
+
+    private Axis axis;
+}

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/Axis.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/Axis.java
@@ -1,0 +1,25 @@
+package net.serenitybdd.screenplay.jenkins.tasks.configuration;
+
+public class Axis {
+
+    private String name;
+    private String[] values;
+
+    public Axis(String name, String[] values) {
+        this.name = name;
+        this.values = values;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getValues() {
+        String dimensions = "";
+        for(String val : values) {
+            dimensions += val + " ";
+        }
+
+        return dimensions;
+    }
+}

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/EditUserDefinedAxis.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/EditUserDefinedAxis.java
@@ -1,0 +1,8 @@
+package net.serenitybdd.screenplay.jenkins.user_interface;
+
+import net.serenitybdd.screenplay.targets.Target;
+
+public class EditUserDefinedAxis {
+    public static final Target EditAxisName = Target.the("code editor").locatedBy("(//div[@descriptorid='hudson.matrix.TextAxis']//input[@class='setting-input validated  '])");
+    public static final Target EditAxisVals = Target.the("code editor").locatedBy("(//div[@descriptorid='hudson.matrix.TextAxis']//input[@class='setting-input'])");
+}

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/NewJobPage.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/NewJobPage.java
@@ -8,8 +8,9 @@ import net.thucydides.core.annotations.DefaultUrl;
 
 @DefaultUrl("/newJob")
 public class NewJobPage extends PageObject {
-    public static final Target Item_Name_Field   = Setting.defining("Item name");
-    public static final Target Freestyle_Project = RadioButton.withLabel("Freestyle project");
-    public static final Target Pipeline          = RadioButton.withLabel("Pipeline");
-    public static final Target External_Project  = RadioButton.withLabel("External Job");
+    public static final Target Item_Name_Field              = Setting.defining("Item name");
+    public static final Target Freestyle_Project            = RadioButton.withLabel("Freestyle project");
+    public static final Target Pipeline                     = RadioButton.withLabel("Pipeline");
+    public static final Target External_Project             = RadioButton.withLabel("External Job");
+    public static final Target Multi_Configuration_Project  = RadioButton.withLabel("Multi-configuration project");
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/ProjectConfigurationPage.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/ProjectConfigurationPage.java
@@ -5,7 +5,8 @@ import net.serenitybdd.screenplay.jenkins.targets.Checkbox;
 import net.serenitybdd.screenplay.targets.Target;
 
 public class ProjectConfigurationPage {
-    public static final Target Execute_Concurrent_Builds = Checkbox.withLabel("Execute concurrent builds if necessary");
-    public static final Target Add_Build_Step = Button.called("Add build step");
-    public static final Target Add_Post_Build_Action = Button.called("Add post-build action");
+    public static final Target Execute_Concurrent_Builds    = Checkbox.withLabel("Execute concurrent builds if necessary");
+    public static final Target Add_Build_Step               = Button.called("Add build step");
+    public static final Target Add_Post_Build_Action        = Button.called("Add post-build action");
+    public static final Target Add_Axis                     = Button.called("Add axis");
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/ViewConfigurationPage.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/ViewConfigurationPage.java
@@ -8,4 +8,5 @@ public class ViewConfigurationPage {
     public static final Target Recurse_In_Subfolders = Target.the("the 'Recurse in subfolders' option").locatedBy("#recurse");
     public static final Target Use_Regular_Expression = Checkbox.withLabel("Use a regular expression to include jobs into the view");
     public static final Target Regular_Expression     = Target.the("the 'Regular expression' field").located(By.name("includeRegex"));
+    public static final Target Display_Multi_Config_Jobs = Target.the("the 'Show multiple configuration jobs' option").locatedBy("#multiConfig");
 }

--- a/build-monitor-acceptance/src/test/java/features/ShouldDisplayMultiConfigJobs.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldDisplayMultiConfigJobs.java
@@ -1,0 +1,60 @@
+package features;
+
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.ProjectWidget;
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.ConfigureEmptyBuildMonitorView;
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.CreateABuildMonitorView;
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.configuration.DisplayAllProjects;
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.configuration.DisplayMultiConfig;
+import environment.JenkinsSandbox;
+import net.serenitybdd.integration.jenkins.JenkinsInstance;
+import net.serenitybdd.junit.runners.SerenityRunner;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import net.serenitybdd.screenplay.jenkins.HaveAMultiConfigProjectCreated;
+import net.serenitybdd.screenplay.jenkins.tasks.configuration.AddAxis;
+import net.serenitybdd.screenplay.jenkins.tasks.configuration.Axis;
+import net.serenitybdd.screenplayx.actions.Navigate;
+import net.thucydides.core.annotations.Managed;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+
+import static net.serenitybdd.screenplay.GivenWhenThen.*;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(SerenityRunner.class)
+public class ShouldDisplayMultiConfigJobs {
+
+    Actor mason = Actor.named("Mason");
+
+    Axis numbers = new Axis("Numbers", new String[] {"1", "2"});
+
+    @Managed public WebDriver hisBrowser;
+
+    @Rule
+    public JenkinsInstance jenkins = JenkinsSandbox.configure().create();
+
+    @Before
+    public void actorCanBrowseTheWeb() {
+        mason.can(BrowseTheWeb.with(hisBrowser));
+    }
+
+    @Test
+    public void displaying_two_configuration_widgets() throws Exception {
+
+        givenThat(mason).wasAbleTo(
+                Navigate.to(jenkins.url()),
+                HaveAMultiConfigProjectCreated.called("MultiProject")
+                    .andConfigureItTo(AddAxis.of(numbers))
+        );
+
+        when(mason).attemptsTo(
+                CreateABuildMonitorView.called("Build Monitor"),
+                ConfigureEmptyBuildMonitorView.to(DisplayMultiConfig.usingDisplayMultiConfigCheckbox(), DisplayAllProjects.usingARegularExpression())
+        );
+
+        then(mason).should(seeThat(ProjectWidget.of("MultiProject").multiConfigBadgeNames(), is("MultiProject » 1:::MultiProject » 2")));
+    }
+}

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
@@ -96,6 +96,11 @@ public class BuildMonitorView extends ListView {
         return currentConfig().shouldDisplayCommitters();
     }
 
+    @SuppressWarnings("unused") // used in the configure-entries.jelly form
+    public boolean isDisplayMultiConfigJob() {
+        return currentConfig().shouldDisplayMultiConfigJobs();
+    }
+
     private static final BuildMonitorInstallation installation = new BuildMonitorInstallation();
 
     @SuppressWarnings("unused") // used in index.jelly
@@ -121,6 +126,7 @@ public class BuildMonitorView extends ListView {
 
             currentConfig().setDisplayCommitters(json.optBoolean("displayCommitters", true));
             currentConfig().setBuildFailureAnalyzerDisplayedField(req.getParameter("buildFailureAnalyzerDisplayedField"));
+            currentConfig().setDisplayMultiConfigJobs(req.getParameter("displayMultiConfigJobs"));
             
             try {
                 currentConfig().setOrder(orderIn(requestedOrdering));
@@ -158,7 +164,7 @@ public class BuildMonitorView extends ListView {
         Collections.sort(projects, currentConfig().getOrder());
 
         for (Job project : projects) {
-            jobs.add(views.viewOf(project));
+            jobs.addAll(views.viewsOf(project));
         }
 
         return jobs;

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -11,6 +11,7 @@ import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.functions.NullSafe
 public class Config {
 
     private boolean displayCommitters;
+    private boolean displayMultiConfigJobs;
     private BuildFailureAnalyzerDisplayedField buildFailureAnalyzerDisplayedField;
     
     public static Config defaultConfig() {
@@ -47,6 +48,18 @@ public class Config {
 
     public void setDisplayCommitters(boolean flag) {
         this.displayCommitters = flag;
+    }
+
+    public void setDisplayMultiConfigJobs(String key) {
+        if(key == null) {
+            this.displayMultiConfigJobs = false;
+        } else {
+            this.displayMultiConfigJobs = true;
+        }
+    }
+
+    public boolean shouldDisplayMultiConfigJobs() {
+        return this.displayMultiConfigJobs;
     }
     
     @Override

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewSerialiser.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewSerialiser.java
@@ -6,30 +6,35 @@ import org.codehaus.jackson.map.JsonSerializer;
 import org.codehaus.jackson.map.SerializerProvider;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * @author Jan Molak
  */
 public class JobViewSerialiser extends JsonSerializer<JobView> {
     @Override
-    public void serialize(JobView job, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-        jgen.writeStartObject();
-        jgen.writeObjectField("name",               job.name());
-        jgen.writeObjectField("url",                job.url());
-        jgen.writeObjectField("status",             job.status());
-        jgen.writeObjectField("hashCode",           job.hashCode());
-        jgen.writeObjectField("progress",           job.progress());
-        jgen.writeObjectField("estimatedDuration",  job.estimatedDuration());
+    public void serialize(JobView parentJob, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        List<JobView> jobs = parentJob.getJobs();
 
-        for (Feature<?> feature : job.features()) {
-            Object serialised = feature.asJson();
+        for(JobView job : jobs) {
+            jgen.writeStartObject();
+            jgen.writeObjectField("name", job.name());
+            jgen.writeObjectField("url", job.url());
+            jgen.writeObjectField("status", job.status());
+            jgen.writeObjectField("hashCode", job.hashCode());
+            jgen.writeObjectField("progress", job.progress());
+            jgen.writeObjectField("estimatedDuration", job.estimatedDuration());
 
-            if (serialised != null) {
-                jgen.writeObjectField(nameOf(serialised), serialised);
+            for (Feature<?> feature : job.features()) {
+                Object serialised = feature.asJson();
+
+                if (serialised != null) {
+                    jgen.writeObjectField(nameOf(serialised), serialised);
+                }
             }
-        }
 
-        jgen.writeEndObject();
+            jgen.writeEndObject();
+        }
     }
 
     private String nameOf(Object serialised) {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViews.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViews.java
@@ -3,6 +3,7 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade.StaticJenkinsAPIs;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features.*;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features.headline.HeadlineConfig;
+import hudson.matrix.MatrixProject;
 import hudson.model.Job;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
@@ -27,7 +28,7 @@ public class JobViews {
         this.config  = config;
     }
 
-    public JobView viewOf(Job<?, ?> job) {
+    public List<JobView> viewsOf(Job<?, ?> job) {
         List<Feature> viewFeatures = newArrayList();
 
         // todo: a more elegant way of assembling the features would be nice
@@ -47,7 +48,12 @@ public class JobViews {
         	viewFeatures.add(new HasBadges());
         }
 
+        if (job instanceof MatrixProject && config.shouldDisplayMultiConfigJobs()) {
+            viewFeatures.add(new ShowMatrixConfigurations());
+        }
+
         boolean isPipelineJob = jenkins.hasPlugin(Pipeline) && job instanceof WorkflowJob;
+
 
         return JobView.of(job, viewFeatures, isPipelineJob);
     }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/BaseFeature.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/BaseFeature.java
@@ -1,0 +1,29 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
+
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
+import hudson.model.Job;
+
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class BaseFeature<JSON extends Object> implements Feature<JSON> {
+    private JobView job;
+
+    @Override
+    public BaseFeature of(JobView jobView) {
+        this.job = jobView;
+
+        return this;
+    }
+
+    @Override
+    public JSON asJson() {
+        return null;
+    }
+
+    @Override
+    public List<JobView> jobs(JobView parentJobView, Job<?, ?> parentJob) {
+        /* Can override this if a feature can create multiple jobviews */
+        return Arrays.asList();
+    }
+}

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeClaimed.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeClaimed.java
@@ -5,7 +5,7 @@ import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
 import hudson.plugins.claim.ClaimBuildAction;
 import org.codehaus.jackson.annotate.JsonProperty;
 
-public class CanBeClaimed implements Feature {
+public class CanBeClaimed extends BaseFeature {
     private JobView job;
 
     @Override

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeDiagnosedForProblems.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeDiagnosedForProblems.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 
-public class CanBeDiagnosedForProblems implements Feature<CanBeDiagnosedForProblems.Problems> {
+public class CanBeDiagnosedForProblems extends BaseFeature<CanBeDiagnosedForProblems.Problems> {
     private JobView job;
     private BuildFailureAnalyzerDisplayedField displayedField;
     

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/Feature.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/Feature.java
@@ -1,10 +1,15 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
+import hudson.model.Job;
+
+import java.util.List;
 
 /**
  * @author Jan Molak
  */
 public interface Feature<JSON extends Object> extends SerialisableAsJsonObjectCalled<JSON> {
     <F extends Feature> F of(JobView jobView);
+
+    List<JobView> jobs(JobView parentJobView, Job<?, ?> parentJob);
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasBadges.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasBadges.java
@@ -17,7 +17,7 @@ import org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildAction;
 /**
  * @author Daniel Beland
  */
-public class HasBadges implements Feature<HasBadges.Badges> {
+public class HasBadges extends BaseFeature<HasBadges.Badges> {
 	private ActionFilter filter = new ActionFilter();
 	private JobView job;
 

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadline.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadline.java
@@ -13,7 +13,7 @@ import static com.google.common.collect.Lists.newArrayList;
 /**
  * @author Jan Molak
  */
-public class HasHeadline implements Feature<Headline> {
+public class HasHeadline extends BaseFeature<Headline> {
 
     private final HeadlineConfig config;
     private JobView job;

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/KnowsCurrentBuildsDetails.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/KnowsCurrentBuildsDetails.java
@@ -17,7 +17,7 @@ import org.codehaus.jackson.annotate.JsonValue;
 /**
  * @author Jan Molak
  */
-public class KnowsCurrentBuildsDetails implements Feature<KnowsCurrentBuildsDetails.CurrentBuilds> {
+public class KnowsCurrentBuildsDetails extends BaseFeature<KnowsCurrentBuildsDetails.CurrentBuilds> {
     private JobView job;
 
     public KnowsCurrentBuildsDetails(/* config */) {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/KnowsLastCompletedBuildDetails.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/KnowsLastCompletedBuildDetails.java
@@ -8,7 +8,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
 /**
  * @author Jan Molak
  */
-public class KnowsLastCompletedBuildDetails implements Feature<KnowsLastCompletedBuildDetails.LastCompletedBuild> {
+public class KnowsLastCompletedBuildDetails extends BaseFeature<KnowsLastCompletedBuildDetails.LastCompletedBuild> {
     private JobView job;
 
     public KnowsLastCompletedBuildDetails(/* config */) {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/ShowMatrixConfigurations.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/ShowMatrixConfigurations.java
@@ -1,0 +1,39 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
+
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade.RelativeLocation;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
+import hudson.matrix.MatrixConfiguration;
+import hudson.matrix.MatrixProject;
+import hudson.model.Job;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static hudson.Util.filter;
+
+public class ShowMatrixConfigurations<JSON extends Object> extends BaseFeature<JSON> {
+    private JobView job;
+
+    @Override
+    public ShowMatrixConfigurations of(JobView jobView) {
+        this.job = jobView;
+
+        return this;
+    }
+
+    @Override
+    public List<JobView> jobs(JobView parentJobView, Job<?, ?> parentJob) {
+        List<JobView> subJobs = new ArrayList<JobView>();
+
+        List<MatrixConfiguration> matrixConfigurations = parentJob instanceof MatrixProject
+                ? filter(parentJob.getAllJobs(), MatrixConfiguration.class)
+                : new ArrayList<MatrixConfiguration>();
+
+        for (Job<?, ?> matrixConfiguration : matrixConfigurations) {
+            subJobs.add(new JobView(matrixConfiguration, parentJobView.features(), false, RelativeLocation.of(matrixConfiguration), new Date()));
+        }
+
+        return subJobs;
+    }
+}

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -67,6 +67,10 @@
     </select>
   </f:entry>
 
+  <f:entry title="${%Show matrix project configurations}" field="multiConfig" help="${descriptor.getHelpFile('showMatrixProjectConfigurations')}">
+    <f:checkbox id="multiConfig" name="displayMultiConfigJobs" checked="${it.isDisplayMultiConfigJob()}"/>
+  </f:entry>
+
   </f:section>
 
   <f:section title="${%Build Monitor - Widget Settings}">

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/help-showMatrixProjectConfigurations.html
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/help-showMatrixProjectConfigurations.html
@@ -1,0 +1,4 @@
+<div>
+    If selected the Build View Monitor will show all build configurations for any multi-configuration project
+    included in the view. The parent multi-configuration job will not be shown.
+</div>

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanShowMatrixConfigurationsTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanShowMatrixConfigurationsTest.java
@@ -1,0 +1,35 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
+
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.JobStateRecipe;
+import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.MatrixConfigurationStateRecipe;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.*;
+import static hudson.model.Result.SUCCESS;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class CanShowMatrixConfigurationsTest {
+    private JobView job;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void should_know_if_a_failing_build_has_been_claimed() throws Exception {
+        List<JobStateRecipe> matrixConfigurations = Arrays.asList(
+            new MatrixConfigurationStateRecipe().withName("A").whereTheLast(build().finishedWith(SUCCESS)),
+            new MatrixConfigurationStateRecipe().withName("B").whereTheLast(build().finishedWith(SUCCESS))
+        );
+
+        job = a(jobView().which(new ShowMatrixConfigurations()).of(a(matrixProject(matrixConfigurations))));
+
+        assertThat(job.getJobs().size(), is(2));
+    }
+}

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/JobStateRecipe.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/JobStateRecipe.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.*;
  * @author Jan Molak
  */
 public class JobStateRecipe implements Supplier<Job<?,?>> {
-    private Job<?, ?> job;
+    protected Job<?, ?> job;
     private RunList<?> runList;
     private Stack<AbstractBuild> buildHistory = new Stack<AbstractBuild>();
     private List<AbstractBuild> allBuilds = new ArrayList<AbstractBuild>();

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/MatrixConfigurationStateRecipe.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/MatrixConfigurationStateRecipe.java
@@ -1,0 +1,20 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar;
+
+import hudson.matrix.MatrixConfiguration;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MatrixConfigurationStateRecipe extends JobStateRecipe {
+    public MatrixConfigurationStateRecipe() {
+        super();
+        job = mock(MatrixConfiguration.class);
+    }
+
+    @Override
+    public MatrixConfigurationStateRecipe withName(String name) {
+        when(job.getName()).thenReturn(name);
+
+        return this;
+    }
+}

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/MatrixProjectStateRecipe.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/MatrixProjectStateRecipe.java
@@ -1,0 +1,34 @@
+package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar;
+
+import hudson.matrix.MatrixProject;
+import hudson.model.Job;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+class MatrixProjectStateRecipe extends JobStateRecipe {
+    private List<JobStateRecipe> matrixConfigurationStateRecipes;
+
+    public MatrixProjectStateRecipe(List<JobStateRecipe> matrixConfigurationStateRecipes) {
+        super();
+
+        job = mock(MatrixProject.class);
+        this.matrixConfigurationStateRecipes = matrixConfigurationStateRecipes;
+
+        Mockito.doReturn(extractJobs(this.matrixConfigurationStateRecipes)).when(job).getAllJobs();
+    }
+
+    private Collection<Job<?, ?>> extractJobs(List<JobStateRecipe> matrixConfigurationStateRecipes) {
+        List<Job<?,?>> jobs = new ArrayList<Job<?, ?>>();
+
+        for (JobStateRecipe matrixConfigurationStateRecipe : matrixConfigurationStateRecipes) {
+            jobs.add(matrixConfigurationStateRecipe.job);
+        }
+
+        return jobs;
+    }
+}

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/Sugar.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/Sugar.java
@@ -4,6 +4,8 @@ import com.google.common.base.Supplier;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.Config;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade.RelativeLocation;
 
+import java.util.List;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +17,10 @@ public class Sugar {
 
     public static JobStateRecipe job() {
         return new JobStateRecipe();
+    }
+
+    public static JobStateRecipe matrixProject(List<JobStateRecipe> matrixConfigurationStateRecipes) {
+        return new MatrixProjectStateRecipe(matrixConfigurationStateRecipes);
     }
 
     public static BuildStateRecipe build() {


### PR DESCRIPTION
Multiconfiguration Jobs included in a Build Monitor View may be configured to show a widget for each build configuration

- Generic support for representing a single Job with multiple JobView instances
- Configurable
- Unit Tested
- Acceptance Tested