### PR TITLE
Changed Add/Remove to Configure

### DIFF
--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
@@ -44,7 +44,7 @@
                 <li class="buttons">
                     <a class="btn"
                        href="configure"
-                       title="Configure the '${it.displayName}' view">Add/Remove Jobs</a>
+                       title="Configure the '${it.displayName}' view">Configure</a>
                 </li>
                 <li>
                     <button class="btn btn-primary" data-ng-click="toggleSettings=false">Done</button>


### PR DESCRIPTION
I find the Add/Remove button misleading. Of course, it allows adding and removing jobs, but it's not only limited to that; it also allows to:
- Configure the view Title, Order By, Display of committers, BFA
- Delete the view

I propose we rename it to Configure.