### PR TITLE
 Add support for large numbers of rows

### DIFF
--- a/build-monitor-plugin/src/main/webapp/scripts/controllers.js
+++ b/build-monitor-plugin/src/main/webapp/scripts/controllers.js
@@ -43,7 +43,7 @@ angular.
                     itemsCount    = itemsOnScreen && itemsOnScreen.length || 1,
                     actualColumns = Math.min(itemsCount, numberOfColumns);
 
-                return (baseFontSizePercentage / Math.max(1, actualColumns));
+                return (baseFontSizePercentage / actualColumns);
             }
         }]).
 

--- a/build-monitor-plugin/src/main/webapp/scripts/controllers.js
+++ b/build-monitor-plugin/src/main/webapp/scripts/controllers.js
@@ -41,10 +41,9 @@ angular.
             function fontSizeFor(itemsOnScreen, numberOfColumns) {
                 var baseFontSizePercentage  = 5,
                     itemsCount    = itemsOnScreen && itemsOnScreen.length || 1,
-                    actualColumns = Math.min(itemsCount, numberOfColumns),
-                    actualRows    = Math.ceil(itemsCount / actualColumns);
+                    actualColumns = Math.min(itemsCount, numberOfColumns);
 
-                return (baseFontSizePercentage / Math.max(actualRows, actualColumns));
+                return (baseFontSizePercentage / Math.max(1, actualColumns));
             }
         }]).
 


### PR DESCRIPTION
My jenkins instance has a large number of projects that it builds (And a number of branches for each project). This creates a large number of rows (Measured in the hundreds). With the current logic this divides my font size so much that it ends up not being rendered at all.
![image](https://user-images.githubusercontent.com/2756533/36692449-1458d2b0-1b06-11e8-88a1-07ed7612ee3d.png)

I propose that only the number of columns should change the font size to allow for expandability.