### PR TITLE
Bump jenkins ver

### DIFF
--- a/build-monitor-acceptance/pom.xml
+++ b/build-monitor-acceptance/pom.xml
@@ -210,7 +210,7 @@
                         <include>**/features/*Test.java</include>
                         <include>**/features/*Should*.java</include>
                     </includes>
-                    <argLine>-Xmx512m -XX:MaxPermSize=512m</argLine>
+                    <argLine>-Xmx2048m -XX:MaxPermSize=512m</argLine>
                     <systemPropertyVariables>
                         <webdriver.driver>${webdriver.driver}</webdriver.driver>
                         <browserstack.url>${browserstack.url}</browserstack.url>
@@ -223,7 +223,7 @@
                         <PLUGINS_DIR>${project.parent.basedir}/build-monitor-plugin/target</PLUGINS_DIR>
                         <NEVER_REPLACE_EXISTING_PLUGINS>false</NEVER_REPLACE_EXISTING_PLUGINS>
                     </environmentVariables>
-                    <forkCount>1</forkCount>
+                    <forkCount>2</forkCount>
                     <reuseForks>true</reuseForks>
                     <rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</rerunFailingTestsCount>
                     <redirectTestOutputToFile>false</redirectTestOutputToFile>

--- a/build-monitor-acceptance/pom.xml
+++ b/build-monitor-acceptance/pom.xml
@@ -15,11 +15,13 @@
 
     <properties>
         <encoding>UTF-8</encoding>
-        <serenity.version>1.2.1-rc.6</serenity.version>
+        <serenity.version>1.9.8</serenity.version>
         <aether.version>1.0.0.v20140518</aether.version>
 
         <webdriver.driver>chrome</webdriver.driver>
         <browserstack.url></browserstack.url>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <profiles>
@@ -115,7 +117,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.4</version>
+            <version>4.5.5</version>
         </dependency>
 
         <!-- serenity -->
@@ -123,6 +125,12 @@
             <groupId>net.serenity-bdd</groupId>
             <artifactId>serenity-core</artifactId>
             <version>${serenity.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.serenity-bdd</groupId>
@@ -148,6 +156,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.zafarkhaja</groupId>
+            <artifactId>java-semver</artifactId>
+            <version>0.9.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
         </dependency>
@@ -167,25 +180,37 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+                    <includes>
+                        <include>**/*UnitTest.java</include>
+                    </includes>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <excludes>
+                        <exclude>**/*UnitTest.java</exclude>
+                    </excludes>
                     <includes>
                         <include>**/features/*Test.java</include>
                         <include>**/features/*Should*.java</include>
                     </includes>
-                    <argLine>-Xmx2048m -XX:MaxPermSize=512m</argLine>
+                    <argLine>-Xmx512m -XX:MaxPermSize=512m</argLine>
                     <systemPropertyVariables>
                         <webdriver.driver>${webdriver.driver}</webdriver.driver>
                         <browserstack.url>${browserstack.url}</browserstack.url>
@@ -194,12 +219,14 @@
                     <environmentVariables>
                         <!-- todo: remove when the acceptance-test-harness is gone -->
                         <BROWSER>htmlunit</BROWSER>
-                        <JENKINS_VERSION>1.642.3</JENKINS_VERSION>
+                        <JENKINS_VERSION>${jenkins.version}</JENKINS_VERSION>
                         <PLUGINS_DIR>${project.parent.basedir}/build-monitor-plugin/target</PLUGINS_DIR>
                         <NEVER_REPLACE_EXISTING_PLUGINS>false</NEVER_REPLACE_EXISTING_PLUGINS>
                     </environmentVariables>
-                    <forkCount>2</forkCount>
+                    <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
+                    <rerunFailingTestsCount>${surefire.rerunFailingTestsCount}</rerunFailingTestsCount>
+                    <redirectTestOutputToFile>false</redirectTestOutputToFile>
                 </configuration>
                 <executions>
                     <execution>
@@ -221,6 +248,28 @@
                         <goals>
                             <goal>aggregate</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>display-info</id>
+                        <configuration>
+                            <rules>
+                                <requireUpperBoundDeps>
+                                    <excludes combine.children="append">
+                                        <exclude>org.springframework:spring-core</exclude>
+                                        <exclude>org.springframework:spring-beans</exclude>
+                                        <exclude>org.eclipse.jetty.websocket:websocket-client</exclude>
+                                        <exclude>org.jenkins-ci:trilead-ssh2</exclude>
+                                        <exclude>commons-io:commons-io</exclude>
+                                        <exclude>commons-codec:commons-codec</exclude>
+                                    </excludes>
+                                </requireUpperBoundDeps>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/build-monitor-acceptance/src/main/java/com/cloudbees/hudson/plugins/folder/tasks/CreateAFolder.java
+++ b/build-monitor-acceptance/src/main/java/com/cloudbees/hudson/plugins/folder/tasks/CreateAFolder.java
@@ -24,7 +24,7 @@ public class CreateAFolder implements Task {
     public <T extends Actor> void performAs(T actor) {
         actor.attemptsTo(
                 Click.on(SidePanel.New_Item_Link),
-                Choose.the(RadioButton.withLabel("Folder")),
+                Choose.the(NewJobPage.Folder),
                 Enter.theValue(name).into(NewJobPage.Item_Name_Field).thenHit(ENTER),
                 Click.on(Save)
         );

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/model/ProjectInformation.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/model/ProjectInformation.java
@@ -1,5 +1,6 @@
 package com.smartcodeltd.jenkinsci.plugins.build_monitor.model;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
@@ -24,7 +25,7 @@ public class ProjectInformation {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("name", name)
                 .add("status", status)
                 .toString();

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/ConfigureEmptyBuildMonitorView.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/ConfigureEmptyBuildMonitorView.java
@@ -22,7 +22,6 @@ public class ConfigureEmptyBuildMonitorView implements Task {
     @Step("{0} configures the Build Monitor View")
     public <T extends Actor> void performAs(T actor) {
         actor.attemptsTo(
-                AddProjects.toAnEmptyBuildMonitor(),
                 configureTheView,
                 SaveTheChangesToBuildMonitor.andExitTheConfigurationScreen()
         );

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/CreateABuildMonitorView.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/CreateABuildMonitorView.java
@@ -8,10 +8,10 @@ import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Task;
 import net.serenitybdd.screenplay.actions.Click;
 import net.serenitybdd.screenplay.actions.Enter;
+import net.serenitybdd.screenplay.jenkins.user_interface.navigation.Buttons;
 import net.thucydides.core.annotations.Step;
 
 import static net.serenitybdd.screenplay.Tasks.instrumented;
-import static org.openqa.selenium.Keys.ENTER;
 
 public class CreateABuildMonitorView implements Task {
     public static CreateABuildMonitorView called(String name) {
@@ -29,8 +29,9 @@ public class CreateABuildMonitorView implements Task {
     public <T extends Actor> void performAs(T actor) {
         actor.attemptsTo(
                 Click.on(JenkinsHomePage.New_View_link),
+                Enter.theValue(buildMonitorName).into(NewViewPage.View_Name),
                 Click.on(NewViewPage.Build_Monitor_View),
-                Enter.theValue(buildMonitorName).into(NewViewPage.View_Name).thenHit(ENTER),
+                Click.on(Buttons.OK),
                 configureBuildMonitor,
                 SaveTheChangesToBuildMonitor.andExitTheConfigurationScreen()
         );

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/ShowBadges.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/ShowBadges.java
@@ -5,6 +5,8 @@ import com.smartcodeltd.jenkinsci.plugins.build_monitor.user_interface.BuildMoni
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Task;
 import net.serenitybdd.screenplay.actions.Click;
+import net.serenitybdd.screenplay.matchers.WebElementStateMatchers;
+import net.serenitybdd.screenplay.waits.WaitUntil;
 import net.thucydides.core.annotations.Step;
 
 import static net.serenitybdd.screenplay.Tasks.instrumented;
@@ -18,7 +20,8 @@ public class ShowBadges implements Task {
     @Override
     public <T extends Actor> void performAs(T actor) {
         actor.attemptsTo(
-                Click.on(BuildMonitorDashboard.Show_Badges)
+            WaitUntil.the(BuildMonitorDashboard.Show_Badges, WebElementStateMatchers.isVisible()),
+            Click.on(BuildMonitorDashboard.Show_Badges)
         );
     }
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/UpdateCenter.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/UpdateCenter.java
@@ -1,6 +1,9 @@
 package net.serenitybdd.integration.jenkins.environment;
 
+import com.github.zafarkhaja.semver.Version;
 import com.google.common.base.Charsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -10,13 +13,27 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 
 public class UpdateCenter {
+
+    private static final Logger Log = LoggerFactory.getLogger(UpdateCenter.class);
+
     private static final String Update_Center_URL_Template
-            = "https://updates.jenkins-ci.org/update-center.json?id=default&version=%s";
+            = "https://updates.jenkins-ci.org/stable-%s/update-center.json";
     private final Path tempDir;
 
-    public UpdateCenter() {
+    private List<Version> jenkinsLTSVersions = Arrays.asList(
+      Version.valueOf("2.107.0"),
+      Version.valueOf("2.89.0"),
+      Version.valueOf("2.73.0"),
+      Version.valueOf("2.60.0"),
+      Version.valueOf("2.46.0")
+    );
+
+
+  public UpdateCenter() {
         this(Directories.Default_Temp_Dir);
     }
 
@@ -33,7 +50,28 @@ public class UpdateCenter {
     }
 
     private URL updateCenterJSONPFor(String jenkinsVersion) throws MalformedURLException {
-        return url(Update_Center_URL_Template, jenkinsVersion);
+        String versionToUse = getUpdateVersionToUse(jenkinsVersion);
+        URL url = url(Update_Center_URL_Template, versionToUse);
+        Log.info("Jenkins update URL is {}", url.toString());
+        return url;
+
+    }
+
+    String getUpdateVersionToUse(String jenkinsVersionString) {
+        Version jenkinsVersion = Version.valueOf(jenkinsVersionString);
+        Version lowestLTS = jenkinsLTSVersions.get(jenkinsLTSVersions.size() - 1);
+        if (jenkinsVersion.lessThan(lowestLTS)) {
+            throw new RuntimeException("Can't test Jenkins versions lower than " + lowestLTS + ".");
+        }
+        Version versionToUse = null;
+        for (Version ltsVersion : jenkinsLTSVersions) {
+            if (jenkinsVersion.greaterThanOrEqualTo(ltsVersion)) {
+                versionToUse = ltsVersion;
+                break;
+            }
+        }
+        assert versionToUse != null; //versionToUse should never be null since we already made sure jenkinsVersion isn't lower than the lowest LTS.
+        return versionToUse.getMajorVersion() + "." + versionToUse.getMinorVersion();
     }
 
     private String stripJSONPEnvelope(Path jsonp) throws IOException {

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/logging/LoggerOutputStream.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/logging/LoggerOutputStream.java
@@ -2,6 +2,7 @@ package net.serenitybdd.integration.jenkins.logging;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 
 public class LoggerOutputStream extends OutputStream {
     private Witness witness;
@@ -16,7 +17,7 @@ public class LoggerOutputStream extends OutputStream {
     public void write(int b) throws IOException {
         byte[] bytes = new byte[1];
         bytes[0] = (byte) (b & 0xff);
-        buffer = buffer + new String(bytes);
+        buffer = buffer + new String(bytes, Charset.forName("UTF-8"));
 
         if (buffer.endsWith("\n")) {
             buffer = buffer.substring(0, buffer.length() - 1);

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/process/JenkinsProcess.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/process/JenkinsProcess.java
@@ -1,5 +1,6 @@
 package net.serenitybdd.integration.jenkins.process;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jdeferred.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,7 @@ public class JenkinsProcess {
     private JenkinsLogWatcher jenkinsLogWatcher;
     private Thread jenkinsLogWatcherThread;
 
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "FindBugs does not like the JAVA_HOME resolve")
     public JenkinsProcess(@NotNull Path java, @NotNull Path jenkinsWar, @NotNull int port, @NotNull Path jenkinsHome) {
         Log.debug("jenkins.war:  {}", jenkinsWar.toAbsolutePath());
         Log.debug("JENKINS_HOME: {}", jenkinsHome.toAbsolutePath());
@@ -44,6 +46,8 @@ public class JenkinsProcess {
         process = process(java,
                 "-Duser.language=en",
                 "-Dhudson.Main.development=true",
+                "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
+                "-Djava.util.logging=DEBUG",
                 "-jar", jenkinsWar.toString(),
                 "--ajp13Port=-1",
                 "--httpPort=" + port
@@ -122,5 +126,9 @@ public class JenkinsProcess {
         return OS.contains("win")
                 ? asList("cmd.exe", "/C", command.toString())
                 : asList(command.toString());
+    }
+
+    public JenkinsLogWatcher getJenkinsLogWatcher() {
+        return jenkinsLogWatcher;
     }
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/utils/CommandLineTools.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/utils/CommandLineTools.java
@@ -8,24 +8,24 @@ import static net.serenitybdd.integration.utils.Nulls.coalesce;
 
 public class CommandLineTools {
     public static Path java() {
-        Path javaHome = Paths.get(coalesce(
-                System.getenv("JENKINS_JAVA_HOME"),
-                System.getenv("JAVA_HOME"),
-                System.getProperty("java.home")
-        ));
-        
-        Path javaBin = null;
-        if (Files.exists(javaHome.resolve("bin/java"))) {
-        	javaBin = javaHome.resolve("bin/java");
-        }
-        else if (Files.exists(javaHome.resolve("bin/java.exe"))) {
-        	javaBin = javaHome.resolve("bin/java.exe");
-        }
-
-        if (! Files.isExecutable(javaBin)) {
+        String javaHomeString = coalesce(System.getenv("JENKINS_JAVA_HOME"), System.getenv("JAVA_HOME"),
+          System.getProperty("java.home"));
+        if (javaHomeString == null) {
             throw new RuntimeException("'java' executable not found. Please set the JAVA_HOME env variable to point to your Java home directory.");
         }
+        Path javaHome = Paths.get(javaHomeString);
 
+        Path javaBin;
+        if (Files.exists(javaHome.resolve("bin/java"))) {
+        	javaBin = javaHome.resolve("bin/java");
+        } else if (Files.exists(javaHome.resolve("bin/java.exe"))) {
+        	javaBin = javaHome.resolve("bin/java.exe");
+        } else {
+            throw new RuntimeException("'java' executable not found. Please set the JAVA_HOME env variable to point to your Java home directory.");
+        }
+        if (!Files.isExecutable(javaBin)) {
+            throw new RuntimeException("'java' executable not found. Please set the JAVA_HOME env variable to point to your Java home directory.");
+        }
         return javaBin;
     }
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/HaveAProjectCreated.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/HaveAProjectCreated.java
@@ -5,6 +5,8 @@ import net.serenitybdd.screenplay.Task;
 import net.serenitybdd.screenplay.actions.Click;
 import net.serenitybdd.screenplay.jenkins.tasks.CreateAFreestyleProject;
 import net.serenitybdd.screenplay.jenkins.tasks.configuration.TodoList;
+import net.serenitybdd.screenplay.jenkins.user_interface.navigation.Buttons;
+import net.serenitybdd.screenplay.jenkins.user_interface.navigation.SidePanel;
 import net.thucydides.core.annotations.Step;
 
 import static net.serenitybdd.screenplay.Tasks.instrumented;
@@ -27,7 +29,7 @@ public class HaveAProjectCreated implements Task {
     public <T extends Actor> void performAs(T actor) {
         actor.attemptsTo(
                 CreateAFreestyleProject.called(projectName).andConfigureItTo(requiredConfiguration),
-                Click.on(Back_to_Dashboard)
+                Click.on(SidePanel.Back_to_Dashboard)
         );
     }
 

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/actions/EnterCode.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/actions/EnterCode.java
@@ -3,6 +3,8 @@ package net.serenitybdd.screenplay.jenkins.actions;
 import com.google.common.base.Joiner;
 import net.serenitybdd.screenplay.Action;
 import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.actions.Click;
+import net.serenitybdd.screenplayx.actions.Scroll;
 import net.serenitybdd.screenplay.targets.Target;
 import net.serenitybdd.screenplayx.actions.Evaluate;
 import net.thucydides.core.annotations.Step;
@@ -44,7 +46,9 @@ public class EnterCode {
         @Override
         @Step("{0} enters '#code' into the code editor field")
         public <T extends Actor> void performAs(T actor) {
-            actor.attemptsTo(Evaluate.javascript(
+            actor.attemptsTo(
+              Click.on(target),
+              Evaluate.javascript(
                     setCodeMirrorValueTo(code),
                     target.resolveFor(actor)
             ));

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/CreateAProject.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/CreateAProject.java
@@ -7,13 +7,12 @@ import net.serenitybdd.screenplay.actions.Enter;
 import net.serenitybdd.screenplay.jenkins.actions.Choose;
 import net.serenitybdd.screenplay.jenkins.tasks.configuration.TodoList;
 import net.serenitybdd.screenplay.jenkins.user_interface.NewJobPage;
+import net.serenitybdd.screenplay.jenkins.user_interface.navigation.Buttons;
 import net.serenitybdd.screenplay.jenkins.user_interface.navigation.SidePanel;
 import net.serenitybdd.screenplay.targets.Target;
 import net.thucydides.core.annotations.Step;
 
 import static net.serenitybdd.screenplay.Tasks.instrumented;
-import static net.serenitybdd.screenplay.jenkins.user_interface.navigation.Buttons.Save;
-import static org.openqa.selenium.Keys.ENTER;
 
 class CreateAProject implements Task {
     public static CreateAProject called(String name) {
@@ -37,10 +36,11 @@ class CreateAProject implements Task {
     public <T extends Actor> void performAs(T actor) {
         actor.attemptsTo(
                 Click.on(SidePanel.New_Item_Link),
+                Enter.theValue(name).into(NewJobPage.Item_Name_Field),
                 Choose.the(projectType),
-                Enter.theValue(name).into(NewJobPage.Item_Name_Field).thenHit(ENTER),
+                Click.on(Buttons.OK),
                 configureTheProject,
-                Click.on(Save)
+                Click.on(Buttons.Save)
         );
     }
 

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/build_steps/AddABuildStep.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/build_steps/AddABuildStep.java
@@ -15,7 +15,7 @@ public class AddABuildStep implements Task {
 
     @Step("{0} adds the '#buildStepName' build step")
     @Override
-    public <T extends Actor> void performAs(T actor) {
+    public <T extends Actor> void performAs(final T actor) {
         actor.attemptsTo(
                 Scroll.to(ProjectConfigurationPage.Add_Build_Step),
                 Click.on(ProjectConfigurationPage.Add_Build_Step),

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/NewJobPage.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/NewJobPage.java
@@ -1,15 +1,14 @@
 package net.serenitybdd.screenplay.jenkins.user_interface;
 
-import net.serenitybdd.screenplay.jenkins.targets.Setting;
 import net.serenitybdd.core.pages.PageObject;
-import net.serenitybdd.screenplay.jenkins.targets.RadioButton;
 import net.serenitybdd.screenplay.targets.Target;
 import net.thucydides.core.annotations.DefaultUrl;
 
 @DefaultUrl("/newJob")
 public class NewJobPage extends PageObject {
-    public static final Target Item_Name_Field   = Setting.defining("Item name");
-    public static final Target Freestyle_Project = RadioButton.withLabel("Freestyle project");
-    public static final Target Pipeline          = RadioButton.withLabel("Pipeline");
-    public static final Target External_Project  = RadioButton.withLabel("External Job");
+    public static final Target Item_Name_Field   = Target.the("Item name").locatedBy("//*[@id='name']");
+    public static final Target Freestyle_Project = Target.the("Freestyle project").locatedBy("//*[@id=\"j-add-item-type-standalone-projects\"]/ul/li[label/input[@value='hudson.model.FreeStyleProject']]");
+    public static final Target Pipeline          = Target.the("Pipeline").locatedBy("//*[@id=\"j-add-item-type-standalone-projects\"]/ul/li[label/input[@value='org.jenkinsci.plugins.workflow.job.WorkflowJob']]");
+    public static final Target Folder            = Target.the("Folder").locatedBy("//*[@id=\"j-add-item-type-nested-projects\"]/ul/li[label/input[@value='com.cloudbees.hudson.plugins.folder.Folder']]");
+    public static final Target External_Project  = Target.the("External Job").locatedBy("//*[@id=\"j-add-item-type-standalone-projects\"]/ul/li[label/input[@value='hudson.model.ExternalJob']]");
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/NewViewPage.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/NewViewPage.java
@@ -8,6 +8,6 @@ import net.thucydides.core.annotations.DefaultUrl;
 
 @DefaultUrl("/newView")
 public class NewViewPage extends PageObject {
-    public static final Target View_Name          = Setting.defining("View name");
+    public static final Target View_Name          = Target.the("View name").locatedBy("//*[@id='name']");
     public static final Target Build_Monitor_View = RadioButton.withLabel("Build Monitor View");
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/navigation/Breadcrumbs.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/navigation/Breadcrumbs.java
@@ -1,12 +1,11 @@
 package net.serenitybdd.screenplay.jenkins.user_interface.navigation;
 
-import net.serenitybdd.screenplay.jenkins.targets.Link;
 import net.serenitybdd.screenplay.targets.Target;
 
 import static java.lang.String.format;
 
 public class Breadcrumbs {
-    public static final Target Jenkins_Link = Link.to("Jenkins");
+    public static final Target Jenkins_Link = Target.the("the 'Jenkins' link").locatedBy("//a[./text()='Jenkins']");
 
     public static Target linkTo(String name) {
         return Target.the(format("the '%s' breadcrumb link", name))

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/navigation/SidePanel.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/navigation/SidePanel.java
@@ -5,5 +5,5 @@ import net.serenitybdd.screenplay.jenkins.targets.Link;
 
 public class SidePanel {
     public static final Target New_Item_Link = Link.to("New Item");
-    public static final Target Back_to_Dashboard = Link.to("Back to Dashboard");
+    public static final Target Back_to_Dashboard = Target.the("Back to Dashboard").locatedBy("//*[@id=\"tasks\"]/div/a[@href='/']");
 }

--- a/build-monitor-acceptance/src/test/java/features/AbstractTestBase.java
+++ b/build-monitor-acceptance/src/test/java/features/AbstractTestBase.java
@@ -1,0 +1,28 @@
+package features;
+
+import org.junit.After;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+public abstract class AbstractTestBase {
+    private WebDriver webDriver;
+
+    WebDriver getWebDriver() {
+        if (webDriver == null) {
+            ChromeOptions options = new ChromeOptions();
+            options.addArguments("--lang=en");
+            webDriver = new ChromeDriver(options);
+            webDriver.manage().window().setSize(new Dimension(1440, 900));
+        }
+        return webDriver;
+    }
+
+    @After
+    public void tearDown() {
+        if (webDriver != null) {
+            webDriver.quit();
+        }
+    }
+}

--- a/build-monitor-acceptance/src/test/java/features/BuildMonitorShouldBeEasyToSetUp.java
+++ b/build-monitor-acceptance/src/test/java/features/BuildMonitorShouldBeEasyToSetUp.java
@@ -1,9 +1,7 @@
 package features;
 
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.ProjectWidget;
-import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.ConfigureEmptyBuildMonitorView;
-import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.CreateABuildMonitorView;
-import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.configuration.DisplayAllProjects;
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.HaveABuildMonitorViewCreated;
 import environment.JenkinsSandbox;
 import net.serenitybdd.integration.jenkins.JenkinsInstance;
 import net.serenitybdd.junit.runners.SerenityRunner;
@@ -11,29 +9,28 @@ import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
 import net.serenitybdd.screenplay.jenkins.HaveAProjectCreated;
 import net.serenitybdd.screenplayx.actions.Navigate;
-import net.thucydides.core.annotations.Managed;
 import net.thucydides.core.annotations.Title;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.WebDriver;
 
-import static net.serenitybdd.screenplay.GivenWhenThen.*;
+import static net.serenitybdd.screenplay.GivenWhenThen.givenThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.seeThat;
+import static net.serenitybdd.screenplay.GivenWhenThen.then;
+import static net.serenitybdd.screenplay.GivenWhenThen.when;
 import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isCurrentlyVisible;
 
 @RunWith(SerenityRunner.class)
-public class BuildMonitorShouldBeEasyToSetUp {
+public class BuildMonitorShouldBeEasyToSetUp extends AbstractTestBase {
 
     Actor anna = Actor.named("Anna");
-
-    @Managed public WebDriver herBrowser;
 
     @Rule public JenkinsInstance jenkins = JenkinsSandbox.configure().create();
 
     @Before
     public void actorCanBrowseTheWeb() {
-        anna.can(BrowseTheWeb.with(herBrowser));
+        anna.can(BrowseTheWeb.with(getWebDriver()));
     }
 
     @Test
@@ -45,10 +42,7 @@ public class BuildMonitorShouldBeEasyToSetUp {
                 HaveAProjectCreated.called("My Awesome App")
         );
 
-        when(anna).attemptsTo(
-                CreateABuildMonitorView.called("Build Monitor"),
-                ConfigureEmptyBuildMonitorView.to(DisplayAllProjects.usingARegularExpression())
-        );
+        when(anna).attemptsTo(HaveABuildMonitorViewCreated.showingAllTheProjects());
 
         then(anna).should(seeThat(ProjectWidget.of("My Awesome App").state(), isCurrentlyVisible()));
     }

--- a/build-monitor-acceptance/src/test/java/features/ProjectStatusShouldBeEasyToDetermine.java
+++ b/build-monitor-acceptance/src/test/java/features/ProjectStatusShouldBeEasyToDetermine.java
@@ -23,17 +23,15 @@ import static com.smartcodeltd.jenkinsci.plugins.build_monitor.model.ProjectStat
 import static net.serenitybdd.screenplay.GivenWhenThen.*;
 
 @RunWith(SerenityRunner.class)
-public class ProjectStatusShouldBeEasyToDetermine {
+public class ProjectStatusShouldBeEasyToDetermine extends AbstractTestBase {
 
-    Actor anna = Actor.named("Anna");
-
-    @Managed public WebDriver herBrowser;
+    private Actor anna = Actor.named("Anna");
 
     @Rule public JenkinsInstance jenkins = JenkinsSandbox.configure().create();
 
     @Before
     public void actorCanBrowseTheWeb() {
-        anna.can(BrowseTheWeb.with(herBrowser));
+        anna.can(BrowseTheWeb.with(getWebDriver()));
     }
 
     @Test

--- a/build-monitor-acceptance/src/test/java/features/ShouldDescribeEachProject.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldDescribeEachProject.java
@@ -25,13 +25,9 @@ import static net.serenitybdd.screenplay.GivenWhenThen.*;
 import static org.hamcrest.Matchers.is;
 
 @RunWith(SerenityRunner.class)
-public class ShouldDescribeEachProject {
+public class ShouldDescribeEachProject extends AbstractTestBase {
 
-
-    Actor dave = Actor.named("Dave");
-
-    @Managed
-    public WebDriver hisBrowser;
+    private Actor dave = Actor.named("Dave");
 
     @Rule
     public JenkinsInstance jenkins = JenkinsSandbox.configure().afterStart(
@@ -40,7 +36,7 @@ public class ShouldDescribeEachProject {
 
     @Before
     public void actorCanBrowseTheWeb() {
-        dave.can(BrowseTheWeb.with(hisBrowser));
+        dave.can(BrowseTheWeb.with(getWebDriver()));
     }
 
     @Test

--- a/build-monitor-acceptance/src/test/java/features/ShouldDisplayBadges.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldDisplayBadges.java
@@ -20,6 +20,7 @@ import net.thucydides.core.annotations.Managed;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
 
@@ -28,11 +29,10 @@ import static net.serenitybdd.screenplay.jenkins.tasks.configuration.build_steps
 import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isCurrentlyVisible;
 
 @RunWith(SerenityRunner.class)
-public class ShouldDisplayBadges {
+//Broken
+public class ShouldDisplayBadges extends AbstractTestBase {
 
     Actor paul = Actor.named("Paul");
-
-    @Managed public WebDriver hisBrowser;
 
     @Rule public JenkinsInstance jenkins = JenkinsSandbox.configure().afterStart(
             InstallPlugins.fromUpdateCenter("buildtriggerbadge", "groovy-postbuild")
@@ -40,7 +40,7 @@ public class ShouldDisplayBadges {
 
     @Before
     public void actorCanBrowseTheWeb() {
-        paul.can(BrowseTheWeb.with(hisBrowser));
+        paul.can(BrowseTheWeb.with(getWebDriver()));
     }
 
     @Test

--- a/build-monitor-acceptance/src/test/java/features/ShouldDisplayConcurrentBuilds.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldDisplayConcurrentBuilds.java
@@ -25,13 +25,10 @@ import static net.serenitybdd.screenplay.GivenWhenThen.*;
 import static org.hamcrest.Matchers.is;
 
 @RunWith(SerenityRunner.class)
-public class ShouldDisplayConcurrentBuilds {
+public class ShouldDisplayConcurrentBuilds extends AbstractTestBase {
     private static String My_App = "My App";
 
     Actor dave = Actor.named("Dave");
-
-    @Managed
-    public WebDriver hisBrowser;
 
     @Rule
     public JenkinsInstance jenkins = JenkinsSandbox.configure().afterStart(
@@ -40,7 +37,7 @@ public class ShouldDisplayConcurrentBuilds {
 
     @Before
     public void actorCanBrowseTheWeb() {
-        dave.can(BrowseTheWeb.with(hisBrowser));
+        dave.can(BrowseTheWeb.with(getWebDriver()));
     }
 
     @Test

--- a/build-monitor-acceptance/src/test/java/features/ShouldDisplayPipelineStage.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldDisplayPipelineStage.java
@@ -16,6 +16,7 @@ import net.thucydides.core.annotations.Managed;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
 
@@ -23,12 +24,9 @@ import static net.serenitybdd.screenplay.GivenWhenThen.*;
 import static org.hamcrest.Matchers.containsString;
 
 @RunWith(SerenityRunner.class)
-public class ShouldDisplayPipelineStage {
+public class ShouldDisplayPipelineStage extends AbstractTestBase {
 
     Actor donald = Actor.named("Donald");
-
-    @Managed
-    public WebDriver hisBrowser;
 
     @Rule
     public JenkinsInstance jenkins = JenkinsSandbox.configure().afterStart(
@@ -37,7 +35,7 @@ public class ShouldDisplayPipelineStage {
 
     @Before
     public void actorCanBrowseTheWeb() {
-        donald.can(BrowseTheWeb.with(hisBrowser));
+        donald.can(BrowseTheWeb.with(getWebDriver()));
     }
 
     @Test

--- a/build-monitor-acceptance/src/test/java/features/ShouldSupportCloudBeesFolders.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldSupportCloudBeesFolders.java
@@ -17,6 +17,7 @@ import net.thucydides.core.annotations.Managed;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
 
@@ -24,11 +25,9 @@ import static net.serenitybdd.screenplay.GivenWhenThen.*;
 import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
 
 @RunWith(SerenityRunner.class)
-public class ShouldSupportCloudBeesFolders {
+public class ShouldSupportCloudBeesFolders extends AbstractTestBase {
 
     Actor anna = Actor.named("Anna");
-
-    @Managed public WebDriver herBrowser;
 
     @Rule public JenkinsInstance jenkins = JenkinsSandbox.configure().afterStart(
             InstallPlugins.fromUpdateCenter("cloudbees-folder")
@@ -36,7 +35,7 @@ public class ShouldSupportCloudBeesFolders {
 
     @Before
     public void actorCanBrowseTheWeb() {
-        anna.can(BrowseTheWeb.with(herBrowser));
+        anna.can(BrowseTheWeb.with(getWebDriver()));
     }
 
     @Test

--- a/build-monitor-acceptance/src/test/java/features/ShouldSupportExternalProjects.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldSupportExternalProjects.java
@@ -4,6 +4,7 @@ import com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.ProjectWidget;
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.HaveABuildMonitorViewCreated;
 import environment.JenkinsSandbox;
 import net.serenitybdd.integration.jenkins.JenkinsInstance;
+import net.serenitybdd.integration.jenkins.environment.rules.InstallPlugins;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
@@ -15,6 +16,7 @@ import net.thucydides.core.annotations.Managed;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
 
@@ -23,17 +25,17 @@ import static com.smartcodeltd.jenkinsci.plugins.build_monitor.model.ProjectStat
 import static net.serenitybdd.screenplay.GivenWhenThen.*;
 
 @RunWith(SerenityRunner.class)
-public class ShouldSupportExternalProjects {
+public class ShouldSupportExternalProjects extends AbstractTestBase {
 
     Actor maggie = Actor.named("Maggie");
 
-    @Managed public WebDriver herBrowser;
-
-    @Rule public JenkinsInstance jenkins = JenkinsSandbox.configure().create();
+    @Rule public JenkinsInstance jenkins = JenkinsSandbox.configure().afterStart(
+      InstallPlugins.fromUpdateCenter("external-monitor-job")
+    ).create();
 
     @Before
     public void actorCanBrowseTheWeb() {
-        maggie.can(BrowseTheWeb.with(herBrowser))
+        maggie.can(BrowseTheWeb.with(getWebDriver()))
               .can(InteractWithJenkinsAPI.using(jenkins.client()));
     }
 

--- a/build-monitor-acceptance/src/test/java/features/ShouldTellWhatBrokeTheBuild.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldTellWhatBrokeTheBuild.java
@@ -15,6 +15,7 @@ import net.thucydides.core.annotations.Managed;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
 
@@ -22,11 +23,9 @@ import static net.serenitybdd.screenplay.GivenWhenThen.*;
 import static org.hamcrest.Matchers.containsString;
 
 @RunWith(SerenityRunner.class)
-public class ShouldTellWhatBrokeTheBuild {
+public class ShouldTellWhatBrokeTheBuild extends AbstractTestBase {
 
     Actor dave = Actor.named("Dave");
-
-    @Managed public WebDriver hisBrowser;
 
     @Rule public JenkinsInstance jenkins = JenkinsSandbox.configure().afterStart(
             InstallPlugins.fromUpdateCenter("cloudbees-folder", "build-failure-analyzer")
@@ -34,7 +33,7 @@ public class ShouldTellWhatBrokeTheBuild {
 
     @Before
     public void actorCanBrowseTheWeb() {
-        dave.can(BrowseTheWeb.with(hisBrowser));
+        dave.can(BrowseTheWeb.with(getWebDriver()));
     }
 
     @Test

--- a/build-monitor-acceptance/src/test/java/features/ShouldTellWhoIsFixingTheBrokenBuild.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldTellWhoIsFixingTheBrokenBuild.java
@@ -27,11 +27,9 @@ import static net.serenitybdd.screenplay.GivenWhenThen.*;
 import static org.hamcrest.core.Is.is;
 
 @RunWith(SerenityRunner.class)
-public class ShouldTellWhoIsFixingTheBrokenBuild {
+public class ShouldTellWhoIsFixingTheBrokenBuild extends AbstractTestBase {
 
     JenkinsUser ben = JenkinsUser.named("Ben");
-
-    @Managed public WebDriver hisBrowser;
 
     @Rule public JenkinsInstance jenkins = JenkinsSandbox.configure().afterStart(
             InstallPlugins.fromUpdateCenter("claim"),
@@ -40,7 +38,7 @@ public class ShouldTellWhoIsFixingTheBrokenBuild {
 
     @Before
     public void actorCanBrowseTheWeb() {
-        ben.can(BrowseTheWeb.with(hisBrowser));
+        ben.can(BrowseTheWeb.with(getWebDriver()));
     }
 
     @Test

--- a/build-monitor-acceptance/src/test/java/net/serenitybdd/integration/jenkins/environment/UpdateCenterUnitTest.java
+++ b/build-monitor-acceptance/src/test/java/net/serenitybdd/integration/jenkins/environment/UpdateCenterUnitTest.java
@@ -1,0 +1,24 @@
+package net.serenitybdd.integration.jenkins.environment;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UpdateCenterUnitTest {
+
+    private UpdateCenter updateCenter = new UpdateCenter();
+
+    @Test(expected = RuntimeException.class)
+    public void getUpdateVersionToUseTooLow() {
+        String versionToUse = updateCenter.getUpdateVersionToUse("2.45");
+    }
+
+    @Test
+    public void getUpdateVersionToUse() {
+        Assert.assertEquals("2.46", updateCenter.getUpdateVersionToUse("2.46.0"));
+        Assert.assertEquals("2.46", updateCenter.getUpdateVersionToUse("2.47.0"));
+        Assert.assertEquals("2.60", updateCenter.getUpdateVersionToUse("2.72.0"));
+        Assert.assertEquals("2.73", updateCenter.getUpdateVersionToUse("2.88.0"));
+        Assert.assertEquals("2.89", updateCenter.getUpdateVersionToUse("2.106.9999"));
+        Assert.assertEquals("2.107", updateCenter.getUpdateVersionToUse("2.108.0"));
+    }
+}

--- a/build-monitor-plugin/pom.xml
+++ b/build-monitor-plugin/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>1.4</version>
+            <version>2.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -156,6 +156,12 @@
             <artifactId>claim</artifactId>
             <version>2.8</version>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>matrix-project</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -175,12 +181,30 @@
             <version>2.4</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>1.3</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.5</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>script-security</artifactId>
+            <version>1.21</version>
+            <optional>true</optional>
+        </dependency>
         <!-- /Jenkins CI plugins supported by the Build Monitor -->
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -191,7 +215,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.10.19    </version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -199,6 +223,11 @@
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>com.github.detro.ghostdriver</groupId>
@@ -210,7 +239,7 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness</artifactId>
-            <version>${jenkins.version}</version>
+            <version>${jenkins-test-harness.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -238,6 +267,12 @@
             <artifactId>powermock-api-mockito</artifactId>
             <version>1.6.5</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugin/assetbundler/Dispatcher.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugin/assetbundler/Dispatcher.java
@@ -2,12 +2,12 @@ package com.smartcodeltd.jenkinsci.plugin.assetbundler;
 
 import com.smartcodeltd.jenkinsci.plugin.assetbundler.filters.LessCSS;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade.StaticJenkinsAPIs;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Plugin;
 import hudson.util.PluginServletFilter;
 
 import java.io.File;
-import java.net.URISyntaxException;
 import java.net.URL;
 
 /*
@@ -28,11 +28,12 @@ public class Dispatcher extends Plugin {
         PluginServletFilter.addFilter(new LessCSS("/build-monitor-plugin/style.css", pathTo("less/index.less"), new StaticJenkinsAPIs()));
     }
 
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Can never be null as build-monitor-plugin refers to self")
     private URL baseResourceURL() {
         return getWrapper().parent.getPlugin("build-monitor-plugin").baseResourceURL;
     }
 
-    private File pathTo(String asset) throws URISyntaxException {
+    private File pathTo(String asset) {
         return new PathToAsset(baseResourceURL(), asset).toFile();
     }
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/facade/StaticJenkinsAPIs.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/facade/StaticJenkinsAPIs.java
@@ -1,8 +1,10 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Main;
 import hudson.model.PageDecorator;
 import hudson.model.User;
+import hudson.security.csrf.CrumbIssuer;
 import jenkins.model.Jenkins;
 import org.jenkinsci.main.modules.instance_identity.PageDecoratorImpl;
 
@@ -11,6 +13,7 @@ public class StaticJenkinsAPIs {
         return Main.isUnitTest || Main.isDevelopmentMode;
     }
 
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "PageDecoratorImpl is part of Jenkins core and should never be null")
     public String encodedPublicKey() {
         return Jenkins.getInstance().getExtensionList(PageDecorator.class).get(PageDecoratorImpl.class).getEncodedPublicKey();
     }
@@ -23,7 +26,14 @@ public class StaticJenkinsAPIs {
     public String crumbFieldName() {
         Jenkins instance = Jenkins.getInstance();
 
-        return instance.isUseCrumbs() ? instance.getCrumbIssuer().getCrumbRequestField() : ".crumb";
+        if (instance.isUseCrumbs()) {
+          CrumbIssuer crumbIssuer = instance.getCrumbIssuer();
+          if (crumbIssuer == null) {
+                throw new RuntimeException("No CrumbIssuer found");
+            }
+            return crumbIssuer.getCrumbRequestField();
+        }
+        return ".crumb";
     }
 
     public boolean hasPlugin(String pluginName) {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByDisplayName.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByDisplayName.java
@@ -1,11 +1,11 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
 
-import hudson.model.AbstractProject;
 import hudson.model.Job;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
-public class ByDisplayName implements Comparator<Job<?, ?>> {
+public class ByDisplayName implements Comparator<Job<?, ?>>, Serializable {
     @Override
     public int compare(Job<?, ?> a, Job<?, ?> b) {
         return a.getDisplayName().compareToIgnoreCase(b.getDisplayName());

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByEstimatedDuration.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByEstimatedDuration.java
@@ -2,10 +2,11 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
 
 import hudson.model.AbstractProject;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
 
-public class ByEstimatedDuration implements Comparator<AbstractProject<?, ?>> {
+public class ByEstimatedDuration implements Comparator<AbstractProject<?, ?>>, Serializable {
 
     @Override
     public int compare(AbstractProject<?, ?> a, AbstractProject<?,?> b) {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByFullName.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByFullName.java
@@ -1,11 +1,11 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
 
-import hudson.model.AbstractProject;
 import hudson.model.Job;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
-public class ByFullName implements Comparator<Job<?, ?>> {
+public class ByFullName implements Comparator<Job<?, ?>>, Serializable {
     @Override
     public int compare(Job<?, ?> a, Job<?, ?> b) {
         return a.getFullName().compareToIgnoreCase(b.getFullName());

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByLastBuildTime.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByLastBuildTime.java
@@ -2,13 +2,14 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
 
 import hudson.model.Job;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  * Inspired by <a href="https://github.com/Mercynary">@Mercenary</a>'s answer to
  * issue <a href="https://github.com/jan-molak/jenkins-build-monitor-plugin/issues/113">#113</a>.
  */
-public class ByLastBuildTime implements Comparator<Job<?, ?>> {
+public class ByLastBuildTime implements Comparator<Job<?, ?>>, Serializable {
 
     @Override
     public int compare(Job<?, ?> a, Job<?, ?> b) {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByName.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByName.java
@@ -1,11 +1,11 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.order;
 
-import hudson.model.AbstractProject;
 import hudson.model.Job;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
-public class ByName implements Comparator<Job<?, ?>> {
+public class ByName implements Comparator<Job<?, ?>>, Serializable {
     @Override
     public int compare(Job<?, ?> a, Job<?,?> b) {
         return a.getName().compareToIgnoreCase(b.getName());

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByStatus.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByStatus.java
@@ -4,9 +4,10 @@ import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
-public class ByStatus implements Comparator<Job<?, ?>> {
+public class ByStatus implements Comparator<Job<?, ?>>, Serializable {
     @Override
     public int compare(Job<?, ?> a, Job<?, ?> b) {
         return bothProjectsHaveBuildHistory(a, b)
@@ -37,7 +38,13 @@ public class ByStatus implements Comparator<Job<?, ?>> {
         Result lastResultOfA = a.getLastCompletedBuild().getResult();
         Result lastResultOfB = b.getLastCompletedBuild().getResult();
 
-        if (lastResultOfA.isWorseThan(lastResultOfB)) {
+        if (lastResultOfA == null && lastResultOfB == null) {
+            return 0;
+        } else if (lastResultOfA == null) {
+            return -1;
+        } else if (lastResultOfB == null) {
+            return 1;
+        } else if (lastResultOfA.isWorseThan(lastResultOfB)) {
             return -1;
         } else if (lastResultOfA.isBetterThan(lastResultOfB)) {
             return 1;

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/pipeline/WorkflowNodeTraversal.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/pipeline/WorkflowNodeTraversal.java
@@ -1,5 +1,6 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.pipeline;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.support.steps.StageStep;
@@ -7,7 +8,9 @@ import org.jenkinsci.plugins.workflow.support.steps.StageStep;
 import java.util.Collection;
 
 public class WorkflowNodeTraversal extends BreadthFirstNodeTraversal<FlowNode> {
+
     @Override
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Descriptor should never be null")
     protected boolean isStageStep(FlowNode node) {
         return node instanceof StepStartNode
                 && ((StepStartNode) node).getDescriptor().isSubTypeOf(StageStep.class);

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildingPredicate.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildingPredicate.java
@@ -1,8 +1,9 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel;
 
 import com.google.common.base.Predicate;
-
 import hudson.model.Run;
+
+import javax.annotation.Nullable;
 
 public final class BuildingPredicate implements Predicate<Run<?, ?>> {
 
@@ -12,7 +13,10 @@ public final class BuildingPredicate implements Predicate<Run<?, ?>> {
 	}
 	
 	@Override
-	public boolean apply(Run<?, ?> run) {
+	public boolean apply(@Nullable Run<?, ?> run) {
+		if (run == null) {
+			throw new RuntimeException("Run was null");
+		}
 		return run.isBuilding();
 	}
 

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
@@ -1,11 +1,11 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel;
 
 import com.google.common.base.Objects;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade.RelativeLocation;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.duration.Duration;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features.Feature;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -36,6 +36,7 @@ public class JobView {
         return new JobView(job, features, isPipelineJob, RelativeLocation.of(job), new Date());
     }
 
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "systemTime is non-critical and no security should be compromised by mutating")
     public JobView(Job<?, ?> job, List<Feature> features, boolean isPipelineJob, RelativeLocation relative, Date systemTime) {
         this.job           = job;
         this.isPipelineJob = isPipelineJob;

--- a/pom.xml
+++ b/pom.xml
@@ -4,17 +4,20 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <jenkins.version>1.642.3</jenkins.version>
-        <jenkins-test-harness.version>2.5</jenkins-test-harness.version>
+        <jenkins.version>2.46.3</jenkins.version>
+        <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
+        <java.level>8</java.level>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.642.3</version>
+        <version>3.8</version>
     </parent>
 
-    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>build-monitor</artifactId>
     <version>1.12-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -109,7 +112,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
First of all, a lot of changes are to solve requirements made by bumping the Jenkins version/test-harness as that forced a lot of Enforcer rules.

Other than that, there's mostly some changes to Selenium tests since stuff has changed in Jenkins 2.

I also added some environment specific stuff as I had to make the tests run on Windows/WSL, but that should be backwards compatible.