### PR TITLE
Use vw for font-size to cover long project names

### DIFF
--- a/build-monitor-plugin/src/main/webapp/less/module/widget/basic.less
+++ b/build-monitor-plugin/src/main/webapp/less/module/widget/basic.less
@@ -9,11 +9,11 @@
 
     & {
       header h2 {
-        font-size: 2.5em;
+        font-size: 4vw;
       }
 
       .slots .slot {
-        font-size:     1.5em;
+        font-size:     2vw;
         font-weight:   bold;
 
         text-overflow: ellipsis;


### PR DESCRIPTION
When this plugin is used with BitBucket Project and Pull Request discovery plugin, the name does not fit in the status (slot) box. 