### PR TITLE
[JENKINS-55787] Switch labels from entry to checkbox

### DIFF
--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/global.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/global.jelly
@@ -1,7 +1,10 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:section title="${%Build Monitor}" name="build-monitor">
-        <f:entry title="${%Help make Build Monitor better}" help="${descriptor.getHelpFile('permissionToCollectAnonymousUsageStatistics')}">
-            <f:checkbox field="permissionToCollectAnonymousUsageStatistics" checked="${it.descriptor.permissionToCollectAnonymousUsageStatistics}" />
+        <f:entry>
+            <f:checkbox field="permissionToCollectAnonymousUsageStatistics"
+                        title="${%Help make Build Monitor better}"
+                        help="${descriptor.getHelpFile('permissionToCollectAnonymousUsageStatistics')}"
+                        />
         </f:entry>
     </f:section>
 </j:jelly>


### PR DESCRIPTION
[https://issues.jenkins-ci.org/browse/JENKINS-55787](https://issues.jenkins-ci.org/browse/JENKINS-55787)

Basically checkboxes should have labels, splitting the labels away from their checkboxes is poor UX, poor accessibility. This change brings the layout more inline with how normal settings UIs lay out checkboxes.

This supersedes #406 