### PR TITLE
Move settings to config page as default #119

### DIFF
--- a/build-monitor-acceptance/pom.xml
+++ b/build-monitor-acceptance/pom.xml
@@ -175,6 +175,26 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.9.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-common</artifactId>
+            <version>9.4.10.v20180503</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+            <version>9.4.10.v20180503</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>9.4.10.v20180503</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/build-monitor-plugin/pom.xml
+++ b/build-monitor-plugin/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -236,7 +236,12 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.3</version>
         </dependency>
         <dependency>
             <groupId>com.github.detro.ghostdriver</groupId>

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorDescriptor.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorDescriptor.java
@@ -35,6 +35,34 @@ public final class BuildMonitorDescriptor extends ViewDescriptor {
         return FormValidation.ok();
     }
 
+    @SuppressWarnings("unused") // used in the configure-entries.jelly form
+    public FormValidation doCheckFontSize(@QueryParameter String value) {
+        try {
+            float val = Float.parseFloat(value);
+            if (val >= 0.3 && val <= 2) {
+                return FormValidation.ok();
+            } else {
+                return FormValidation.error("Must be >= 0.3 and <= 2");
+            }
+        } catch (NumberFormatException e) {
+            return FormValidation.error("Must be float");
+        }
+    }
+
+    @SuppressWarnings("unused") // used in the configure-entries.jelly form
+    public FormValidation doCheckNumberOfColumns(@QueryParameter String value) {
+        try {
+            int val = Integer.parseInt(value);
+            if (val >= 1 && val <= 8) {
+                return FormValidation.ok();
+            } else {
+                return FormValidation.error("Must be >= 1 and <= 8");
+            }
+        } catch (NumberFormatException e) {
+            return FormValidation.error("Must be integer");
+        }
+    }
+
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
         req.bindJSON(this, json.getJSONObject("build-monitor"));

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -14,7 +14,11 @@ public class Config {
     private BuildFailureAnalyzerDisplayedField buildFailureAnalyzerDisplayedField;
     
     public static Config defaultConfig() {
-        return new Config();
+        Config config = new Config();
+        config.setFontSize(1);
+        config.setNumberOfColumns(2);
+        config.setColourBlindMode(false);
+        return config;
     }
 
     public Comparator<Job<?, ?>> getOrder() {
@@ -32,7 +36,31 @@ public class Config {
     public void setOrder(Comparator<Job<?, ?>> order) {
         this.order = order;
     }
-    
+
+    public float getFontSize() {
+        return fontSize;
+    }
+
+    public void setFontSize(float fontSize) {
+        this.fontSize = fontSize;
+    }
+
+    public int getNumberOfColumns() {
+        return numberOfColumns;
+    }
+
+    public void setNumberOfColumns(int numberOfColumns) {
+        this.numberOfColumns = numberOfColumns;
+    }
+
+    public boolean isColourBlindMode() {
+        return colourBlindMode;
+    }
+
+    public void setColourBlindMode(boolean colourBlindMode) {
+        this.colourBlindMode = colourBlindMode;
+    }
+
     public BuildFailureAnalyzerDisplayedField getBuildFailureAnalyzerDisplayedField() {
         return getOrElse(buildFailureAnalyzerDisplayedField, BuildFailureAnalyzerDisplayedField.Name);
     }
@@ -75,4 +103,11 @@ public class Config {
     }
     
     private Comparator<Job<?, ?>> order;
+
+    private float fontSize;
+
+    private int numberOfColumns;
+
+    private boolean colourBlindMode;
+
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/functions/NullSafety.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/functions/NullSafety.java
@@ -5,6 +5,7 @@ public class NullSafety {
     /**
      * @param value         a value that can be a potential null
      * @param defaultValue  a default to be returned if the value is null
+     * @param <T>           a type
      *
      * @return either value or defaultValue
      */

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/installation/BuildMonitorInstallation.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/installation/BuildMonitorInstallation.java
@@ -22,6 +22,7 @@ public class BuildMonitorInstallation {
     /**
      * Used to make sure that the anonymous Build Monitor stats are not double-counted,
      * as in a typical setup there's one Jenkins, but multiple Build Monitors.
+     * @return anonymous Correlation Id
      */
     public String anonymousCorrelationId() {
         // we only need to calculate this once

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -67,6 +67,18 @@
     </select>
   </f:entry>
 
+  <f:entry title="${%Font size}">
+    <f:textbox name="fontSize" field="fontSize" value="${it.currentFontSize()}" />
+  </f:entry>
+
+  <f:entry title="${%Number of columns}">
+      <f:textbox name="numberOfColumns" field="numberOfColumns" value="${it.currentNumberOfColumns()}" />
+  </f:entry>
+
+  <f:entry title="${%Colour blind mode ?}">
+      <f:checkbox name="colourBlindMode" checked="${it.isColourBlindMode()}"/>
+  </f:entry>
+
   </f:section>
 
   <f:section title="${%Build Monitor - Widget Settings}">

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/index.jelly
@@ -190,6 +190,9 @@
 
                     constant('BUILD_MONITOR_VERSION', '${it.installation.buildMonitorVersion()}').
                     constant('CSRF_CRUMB_FIELD_NAME', '${it.csrfCrumbFieldName}').
+                    constant('DEFAULT_SETTINGS_FONTSIZE', '${it.currentFontSize()}').
+                    constant('DEFAULT_SETTINGS_NUMBEROFCOLUMNS', '${it.currentNumberOfColumns()}').
+                    constant('DEFAULT_SETTINGS_COLOURBLINDMODE', '${it.getColourBlindModeValue()}').
 
                     config(function(proxyProvider, cookieJarProvider, hashCodeProvider) {
                         var hashCodeOf = hashCodeProvider.hashCodeOf;

--- a/build-monitor-plugin/src/main/webapp/scripts/settings.js
+++ b/build-monitor-plugin/src/main/webapp/scripts/settings.js
@@ -2,12 +2,15 @@ angular.
     module('buildMonitor.settings', [ 'buildMonitor.services', 'rzModule']).
 
     controller('controlPanel', ['$scope', 'cookieJar', 'townCrier',
-        function ($scope, cookieJar, townCrier) {
+        'DEFAULT_SETTINGS_FONTSIZE', 'DEFAULT_SETTINGS_NUMBEROFCOLUMNS',
+        'DEFAULT_SETTINGS_COLOURBLINDMODE',
+        function ($scope, cookieJar, townCrier, DEFAULT_SETTINGS_FONTSIZE,
+            DEFAULT_SETTINGS_NUMBEROFCOLUMNS, DEFAULT_SETTINGS_COLOURBLINDMODE) {
             'use strict';
 
-            $scope.settings.fontSize        = cookieJar.get('fontSize',        1);
-            $scope.settings.numberOfColumns = cookieJar.get('numberOfColumns', 2);
-            $scope.settings.colourBlind     = cookieJar.get('colourBlind',     0);
+            $scope.settings.fontSize        = cookieJar.get('fontSize',        DEFAULT_SETTINGS_FONTSIZE);
+            $scope.settings.numberOfColumns = cookieJar.get('numberOfColumns', DEFAULT_SETTINGS_NUMBEROFCOLUMNS);
+            $scope.settings.colourBlind     = cookieJar.get('colourBlind',     DEFAULT_SETTINGS_COLOURBLINDMODE);
             $scope.settings.reduceMotion    = cookieJar.get('reduceMotion',    0);
             $scope.settings.showBadges      = cookieJar.get('showBadges',      0);
 

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorDescriptorTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorDescriptorTest.java
@@ -40,6 +40,68 @@ public class BuildMonitorDescriptorTest {
         assertThat(htmlDecoded(result.getMessage()), containsString("Unmatched closing ')'"));
     }
 
+    @Test
+    public void form_validator_should_allow_fontsize_in_good_range() throws Exception {
+        FormValidation result = validator.doCheckFontSize("1.0");
+
+        assertThat(result.kind, is(OK));
+    }
+
+    @Test
+    public void form_validator_should_refuse_fontsize_under_0_3() throws Exception {
+        FormValidation result = validator.doCheckFontSize("0");
+
+        assertThat(result.kind, is(ERROR));
+        assertThat(htmlDecoded(result.getMessage()), containsString("Must be >= 0.3 and <= 2"));
+    }
+
+    @Test
+    public void form_validator_should_refuse_fontsize_over_2() throws Exception {
+        FormValidation result = validator.doCheckFontSize("2.1");
+
+        assertThat(result.kind, is(ERROR));
+        assertThat(htmlDecoded(result.getMessage()), containsString("Must be >= 0.3 and <= 2"));
+    }
+
+    @Test
+    public void form_validator_should_refuse_fontsize_not_float() throws Exception {
+        FormValidation result = validator.doCheckFontSize("a");
+
+        assertThat(result.kind, is(ERROR));
+        assertThat(htmlDecoded(result.getMessage()), containsString("Must be float"));
+    }
+
+    @Test
+    public void form_validator_should_allow_numberofcolumns_in_good_range() throws Exception {
+        FormValidation result = validator.doCheckNumberOfColumns("1");
+
+        assertThat(result.kind, is(OK));
+    }
+
+    @Test
+    public void form_validator_should_refuse_numberofcolumns_under_1() throws Exception {
+        FormValidation result = validator.doCheckNumberOfColumns("0");
+
+        assertThat(result.kind, is(ERROR));
+        assertThat(htmlDecoded(result.getMessage()), containsString("Must be >= 1 and <= 8"));
+    }
+
+    @Test
+    public void form_validator_should_refuse_numberofcolumns_over_8() throws Exception {
+        FormValidation result = validator.doCheckNumberOfColumns("10");
+
+        assertThat(result.kind, is(ERROR));
+        assertThat(htmlDecoded(result.getMessage()), containsString("Must be >= 1 and <= 8"));
+    }
+
+    @Test
+    public void form_validator_should_refuse_numberofcolumns_not_integer() throws Exception {
+        FormValidation result = validator.doCheckNumberOfColumns("a");
+
+        assertThat(result.kind, is(ERROR));
+        assertThat(htmlDecoded(result.getMessage()), containsString("Must be integer"));
+    }
+
     private String htmlDecoded(String message) {
         return StringEscapeUtils.unescapeHtml(message);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <jenkins.version>2.46.3</jenkins.version>
-        <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
+        <jenkins.version>2.164.3</jenkins.version>
+        <jenkins-test-harness.version>2.53</jenkins-test-harness.version>
         <java.level>8</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.8</version>
+        <version>3.47</version>
     </parent>
 
     <artifactId>build-monitor</artifactId>


### PR DESCRIPTION
This commit allows Jenkins users to specify defaults for build monitor
views when creating the views from the Jenkins UI. End users can still
modify these settings using the widget within build monitor.

This is useful because the defaults do not scale to large numbers of builds
so if a user is creating a build monitor view that they anticipate will
contain a large number of builds they can increase the number of columns
and prevent each end user from having to do that individually.

This is essentially a rebase of @tcolligon's changes in pr #189
and is related to issue #119.