### PR TITLE
https

### DIFF
--- a/build-monitor-plugin/pom.xml
+++ b/build-monitor-plugin/pom.xml
@@ -25,7 +25,7 @@
         </license>
     </licenses>
 
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Build+Monitor+Plugin</url>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Build+Monitor+Plugin</url>
 
     <developers>
         <developer>


### PR DESCRIPTION
The `(?)` marks for plugins rely on this, and thus this should really be changed.