### PR TITLE
Add default settings to Build Monitor Views

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorDescriptor.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorDescriptor.java
@@ -53,4 +53,34 @@ public final class BuildMonitorDescriptor extends ViewDescriptor {
     public void setPermissionToCollectAnonymousUsageStatistics(boolean collect) {
         this.permissionToCollectAnonymousUsageStatistics = collect;
     }
+
+    public FormValidation doCheckMaxColumns(@QueryParameter String value) {
+        try {
+            int intValue = Integer.parseInt(value);
+            if(intValue > 0) {
+                return FormValidation.ok();
+            } else {
+                return FormValidation.error("Must be an integer, greater than 0.");
+            }
+        } catch (NullPointerException npe) {
+            return FormValidation.error("Cannot be null.");
+        } catch (NumberFormatException nfe) {
+            return FormValidation.error("Must be an integer.");
+        }
+    }
+
+    public FormValidation doCheckTextScale(@QueryParameter String value) {
+        try {
+            double doubleValue = Double.parseDouble(value);
+            if(doubleValue > 0.0) {
+                return FormValidation.ok();
+            } else {
+                return FormValidation.error("Must be a double, greater than 0.0.");
+            }
+        } catch (NullPointerException npe) {
+            return FormValidation.error("Cannot be null.");
+        } catch (NumberFormatException nfe) {
+            return FormValidation.error("Must be a double.");
+        }
+    }
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
@@ -96,6 +96,36 @@ public class BuildMonitorView extends ListView {
         return currentConfig().shouldDisplayCommitters();
     }
 
+    // used in the configure-entries.jelly and main-settings.jelly forms
+    @SuppressWarnings("unused")
+    public double getTextScale() {
+        return currentConfig().getTextScale();
+    }
+
+    // used in the configure-entries.jelly and main-settings.jelly forms
+    @SuppressWarnings("unused")
+    public int getMaxColumns() {
+        return currentConfig().getMaxColumns();
+    }
+
+    // used in the configure-entries.jelly and main-settings.jelly forms
+    @SuppressWarnings("unused")
+    public boolean isColourBlindMode() {
+        return currentConfig().inColourBlindMode();
+    }
+
+    // used in the configure-entries.jelly and main-settings.jelly forms
+    @SuppressWarnings("unused")
+    public boolean isReduceMotion() {
+        return currentConfig().reduceMotion();
+    }
+
+    // used in the configure-entries.jelly and main-settings.jelly forms
+    @SuppressWarnings("unused")
+    public boolean isShowBadges() {
+        return currentConfig().showBadges();
+    }
+
     private static final BuildMonitorInstallation installation = new BuildMonitorInstallation();
 
     @SuppressWarnings("unused") // used in index.jelly
@@ -122,7 +152,12 @@ public class BuildMonitorView extends ListView {
 
             String requestedOrdering = req.getParameter("order");
             title                    = req.getParameter("title");
+            String maxColumns        = req.getParameter("maxColumns");
+            String textScale         = req.getParameter("textScale");
 
+            currentConfig().setColourBlindMode(json.optBoolean("colourBlindMode", false));
+            currentConfig().setReduceMotion(json.optBoolean("reduceMotion", false));
+            currentConfig().setShowBadges(json.optBoolean("showBadges", false));
             currentConfig().setDisplayCommitters(json.optBoolean("displayCommitters", true));
             currentConfig().setBuildFailureAnalyzerDisplayedField(req.getParameter("buildFailureAnalyzerDisplayedField"));
             
@@ -130,6 +165,16 @@ public class BuildMonitorView extends ListView {
                 currentConfig().setOrder(orderIn(requestedOrdering));
             } catch (Exception e) {
                 throw new FormException("Can't order projects by " + requestedOrdering, "order");
+            }
+            try {
+                currentConfig().setMaxColumns(Integer.parseInt(maxColumns));
+            } catch (Exception e) {
+                throw new FormException("Invalid value of 'Maximum number of columns': '" + maxColumns + "' (should be double).", maxColumns);
+            }
+            try {
+                currentConfig().setTextScale(Double.parseDouble(textScale));
+            } catch (Exception e) {
+                throw new FormException("Invalid value of 'Text scale': '" + textScale + "' (should be double).", textScale);
             }
         }
     }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -19,7 +19,16 @@ public class Config {
     private BuildFailureAnalyzerDisplayedField buildFailureAnalyzerDisplayedField;
     
     public static Config defaultConfig() {
-        return new Config();
+        Config defaultConfig = new Config();
+
+        // Set default values
+        defaultConfig.setColourBlindMode(false);
+        defaultConfig.setDisplayCommitters(false);
+        defaultConfig.setShowBadges(false);
+        defaultConfig.setMaxColumns(2);
+        defaultConfig.setTextScale(1.0);
+
+        return defaultConfig;
     }
 
     public Comparator<Job<?, ?>> getOrder() {
@@ -47,7 +56,7 @@ public class Config {
     }
 
     public boolean inColourBlindMode() {
-        return getOrElse(colourBlindMode, false);
+        return colourBlindMode;
     }
 
     public void setColourBlindMode(boolean flag) {
@@ -55,7 +64,7 @@ public class Config {
     }
 
     public boolean shouldDisplayCommitters() {
-        return getOrElse(displayCommitters, true);
+        return displayCommitters;
     }
 
     public void setDisplayCommitters(boolean flag) {
@@ -63,7 +72,7 @@ public class Config {
     }
 
     public boolean reduceMotion() {
-        return getOrElse(reduceMotion, false);
+        return reduceMotion;
     }
 
     public void setReduceMotion(boolean flag) {
@@ -71,7 +80,7 @@ public class Config {
     }
 
     public boolean showBadges() {
-        return getOrElse(showBadges, false);
+        return showBadges;
     }
 
     public void setShowBadges(boolean flag) {
@@ -79,7 +88,7 @@ public class Config {
     }
 
     public int getMaxColumns() {
-        return getOrElse(maxColumns, 2);
+        return maxColumns;
     }
 
     public void setMaxColumns(int maxColumns) {
@@ -87,7 +96,7 @@ public class Config {
     }
 
     public double getTextScale() {
-        return getOrElse(textScale, 1.0);
+        return textScale;
     }
 
     public void setTextScale(double scale) {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -10,7 +10,12 @@ import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.functions.NullSafe
 
 public class Config {
 
+    private boolean colourBlindMode;
     private boolean displayCommitters;
+    private boolean reduceMotion;
+    private boolean showBadges;
+    private int maxColumns;
+    private Double textScale;
     private BuildFailureAnalyzerDisplayedField buildFailureAnalyzerDisplayedField;
     
     public static Config defaultConfig() {
@@ -32,15 +37,23 @@ public class Config {
     public void setOrder(Comparator<Job<?, ?>> order) {
         this.order = order;
     }
-    
+
     public BuildFailureAnalyzerDisplayedField getBuildFailureAnalyzerDisplayedField() {
         return getOrElse(buildFailureAnalyzerDisplayedField, BuildFailureAnalyzerDisplayedField.Name);
     }
-    
+
     public void setBuildFailureAnalyzerDisplayedField(String buildFailureAnalyzerDisplayedField) {
         this.buildFailureAnalyzerDisplayedField = BuildFailureAnalyzerDisplayedField.valueOf(buildFailureAnalyzerDisplayedField);
     }
-    
+
+    public boolean inColourBlindMode() {
+        return getOrElse(colourBlindMode, false);
+    }
+
+    public void setColourBlindMode(boolean flag) {
+        this.colourBlindMode = flag;
+    }
+
     public boolean shouldDisplayCommitters() {
         return getOrElse(displayCommitters, true);
     }
@@ -48,7 +61,39 @@ public class Config {
     public void setDisplayCommitters(boolean flag) {
         this.displayCommitters = flag;
     }
-    
+
+    public boolean reduceMotion() {
+        return getOrElse(reduceMotion, false);
+    }
+
+    public void setReduceMotion(boolean flag) {
+        this.reduceMotion = flag;
+    }
+
+    public boolean showBadges() {
+        return getOrElse(showBadges, false);
+    }
+
+    public void setShowBadges(boolean flag) {
+        this.showBadges = flag;
+    }
+
+    public int getMaxColumns() {
+        return getOrElse(maxColumns, 2);
+    }
+
+    public void setMaxColumns(int maxColumns) {
+        this.maxColumns = maxColumns;
+    }
+
+    public Double getTextScale() {
+        return getOrElse(textScale, 1.0);
+    }
+
+    public void setTextScale(Double scale) {
+        this.textScale = scale;
+    }
+
     @Override
     public String toString() {
         return Objects.toStringHelper(this)
@@ -62,17 +107,17 @@ public class Config {
         Name("name"),
         Description("description"),
         None("none");
-    
+
         private final String value;
         BuildFailureAnalyzerDisplayedField(String value) {
             this.value = value;
         }
-    
+
         public String getValue() { return value; }
-    
+
         @Override
         public String toString() { return value; }
     }
-    
+
     private Comparator<Job<?, ?>> order;
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -15,7 +15,7 @@ public class Config {
     private boolean reduceMotion;
     private boolean showBadges;
     private int maxColumns;
-    private Double textScale;
+    private double textScale;
     private BuildFailureAnalyzerDisplayedField buildFailureAnalyzerDisplayedField;
     
     public static Config defaultConfig() {
@@ -86,11 +86,11 @@ public class Config {
         this.maxColumns = maxColumns;
     }
 
-    public Double getTextScale() {
+    public double getTextScale() {
         return getOrElse(textScale, 1.0);
     }
 
-    public void setTextScale(Double scale) {
+    public void setTextScale(double scale) {
         this.textScale = scale;
     }
 

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -72,12 +72,12 @@
 
   <f:section title="${%Build Monitor - Default Display Settings}">
 
-    <f:entry title="${%Text scale}">
-      <f:textbox name="textScale" value="${it.textScale}" clazz="required"/>
+    <f:entry title="${%Text scale}" field="textScale">
+      <f:textbox name="textScale" value="${it.textScale}" />
     </f:entry>
 
-    <f:entry title="${%Maximum number of columns}">
-      <f:textbox name="maxColumns" value="${it.maxColumns}" clazz="required number"/>
+    <f:entry title="${%Maximum number of columns}" field="maxColumns">
+      <f:textbox name="maxColumns" value="${it.maxColumns}" />
     </f:entry>
 
     <f:entry title="${%Enable Colour blind mode}">

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -70,6 +70,30 @@
 
   </f:section>
 
+  <f:section title="${%Build Monitor - Default Display Settings}">
+
+    <f:entry title="${%Text scale}">
+      <f:textbox name="textScale" value="${it.textScale}" clazz="required"/>
+    </f:entry>
+
+    <f:entry title="${%Maximum number of columns}">
+      <f:textbox name="maxColumns" value="${it.maxColumns}" clazz="required number"/>
+    </f:entry>
+
+    <f:entry title="${%Enable Colour blind mode}">
+      <f:checkbox id="colourBlindMode" field="colourBlindMode" />
+    </f:entry>
+
+    <f:entry title="${%Enable Reduce motion}">
+      <f:checkbox id="reduceMotion" field="reduceMotion" />
+    </f:entry>
+
+    <f:entry title="${%Enable Show badges}">
+      <f:checkbox id="showBadges" field="showBadges" />
+    </f:entry>
+
+  </f:section>
+
   <f:section title="${%Build Monitor - Widget Settings}">
 
     <f:entry title="${%Display committers}" help="${descriptor.getHelpFile('displayCommitters')}">

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-    <nav data-ng-controller="controlPanel" data-ng-init="built_at = '${it.installation.buildMonitorBuiltAt()}'">
+    <nav data-ng-controller="controlPanel" data-ng-init="built_at = '${it.installation.buildMonitorBuiltAt()}'; defaults.fontSize = ${it.textScale}; defaults.numberOfColumns = ${it.maxColumns}; defaults.colourBlind = ${it.colourBlindMode}; defaults.reduceMotion = ${it.reduceMotion}; defaults.showBadges = ${it.showBadges}; addCookie()">
         <span data-ng-show="newVersionAvailable" class="notifications">!</span>
         <section data-ng-class="{ showSettings:toggleSettings }">
             <input id="settings-toggle" type="checkbox" class="settings" data-ng-model="toggleSettings" />
@@ -46,6 +46,11 @@
                     <a class="btn"
                        href="configure"
                        title="Configure the '${it.displayName}' view">Configure</a>
+                </li>
+                <li>
+                    <a class="btn"
+                       data-ng-click="resetSettings()"
+                       title="Reset to defaults.' view">Reset to defaults</a>
                 </li>
                 <li>
                     <button class="btn btn-primary" data-ng-click="toggleSettings=false">Done</button>

--- a/build-monitor-plugin/src/main/webapp/scripts/settings.js
+++ b/build-monitor-plugin/src/main/webapp/scripts/settings.js
@@ -5,20 +5,38 @@ angular.
         function ($scope, cookieJar, townCrier) {
             'use strict';
 
-            $scope.settings.fontSize        = cookieJar.get('fontSize',        1);
-            $scope.settings.numberOfColumns = cookieJar.get('numberOfColumns', 2);
-            $scope.settings.colourBlind     = cookieJar.get('colourBlind',     0);
-            $scope.settings.reduceMotion    = cookieJar.get('reduceMotion',    0);
-            $scope.settings.showBadges      = cookieJar.get('showBadges',      0);
-
-            angular.forEach($scope.settings, function(value, name) {
-                $scope.$watch('settings.' + name, function(currentValue) {
-                    cookieJar.put(name, currentValue);
+            $scope.updateCookie = function() {
+                angular.forEach($scope.settings, function(value, name) {
+                    $scope.$watch('settings.' + name, function(currentValue) {
+                        cookieJar.put(name, currentValue);
+                    });
                 });
-            });
+            }
 
-            // that's the minimum viable product .. at its tiniest
-            townCrier.uponNewVersion(function() {
-                $scope.newVersionAvailable = true;
-            });
+            $scope.addCookie = function() {
+                $scope.defaults.colourBlind     = $scope.defaults.colourBlind ? "1" : "0"
+                $scope.defaults.reduceMotion    = $scope.defaults.reduceMotion ? "1" : "0"
+                $scope.defaults.showBadges      = $scope.defaults.showBadges ? "1" : "0"
+
+                $scope.settings.fontSize        = cookieJar.get('fontSize',        $scope.defaults.fontSize);
+                $scope.settings.numberOfColumns = cookieJar.get('numberOfColumns', $scope.defaults.numberOfColumns);
+                $scope.settings.colourBlind     = cookieJar.get('colourBlind',     $scope.defaults.colourBlind);
+                $scope.settings.reduceMotion    = cookieJar.get('reduceMotion',    $scope.defaults.reduceMotion);
+                $scope.settings.showBadges      = cookieJar.get('showBadges',      $scope.defaults.showBadges);
+
+                $scope.updateCookie();
+
+                // that's the minimum viable product .. at its tiniest
+                townCrier.uponNewVersion(function() {
+                    $scope.newVersionAvailable = true;
+                });
+            }
+
+            $scope.resetSettings = function() {
+                angular.forEach($scope.defaults, function(value, name) {
+                    $scope.settings[name] = value;
+                });
+
+                $scope.updateCookie();
+            }
         }]);


### PR DESCRIPTION
- Added settings items to config so default settings can be tracked
  in the plugin, not just the cookie.
- Updated configure-entries.jelly to allow setting of the settings.
- Updated main.settings.jelly to pass default settings from plugin to
  settings.js. Also added a new button to reset settings in cookie to
  default.
- Updated settings.js to use the default settings provided by
  main.settings.jelly. Also added a function to reset settings cookie
  to the default value.

I opened a new pull request as #419 was closed when I deleted the remote branch.