### PR TITLE
Migrate from com.google.common.base.Predicate to java.util.function.Predicate

### DIFF
--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildingPredicate.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildingPredicate.java
@@ -1,6 +1,6 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel;
 
-import com.google.common.base.Predicate;
+import java.util.function.Predicate;
 import hudson.model.Run;
 
 import javax.annotation.Nullable;
@@ -13,7 +13,7 @@ public final class BuildingPredicate implements Predicate<Run<?, ?>> {
 	}
 	
 	@Override
-	public boolean apply(@Nullable Run<?, ?> run) {
+	public boolean test(@Nullable Run<?, ?> run) {
 		if (run == null) {
 			throw new RuntimeException("Run was null");
 		}


### PR DESCRIPTION
Proof of concept sketch as to how to migrate this plugin from `hudson.util.RunList#filter(com.google.common.base.Predicate)` to the `hudson.util.RunList#filter(java.util.function.Predicate)` API being proposed in jenkinsci/jenkins#5220.

This change will not be feasible until jenkinsci/jenkins#5220 is merged and released and Build Monitor View adopts a newer Jenkins core version.