### PR TITLE
[JENKINS-66299] Prepare Build Monitor View for core Guava upgrade

### DIFF
--- a/build-monitor-plugin/pom.xml
+++ b/build-monitor-plugin/pom.xml
@@ -77,14 +77,14 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -1,6 +1,5 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor;
 
-import com.google.common.base.Objects;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.order.ByName;
 import hudson.model.Job;
 
@@ -51,9 +50,7 @@ public class Config {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
-                .add("order", order.getClass().getSimpleName())
-                .toString();
+        return "Config{order=%s}".format(order.getClass().getSimpleName());
     }
 
     // --

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/api/Success.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/api/Success.java
@@ -1,20 +1,19 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.api;
 
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /* package */ class Success<T> {
 
-    private final Stopwatch stopwatch;
+    private final long startTimeNanos;
     private T data;
 
     public Success(T data) {
         this.data = data;
-        this.stopwatch = new Stopwatch();
-        stopwatch.start();
+        this.startTimeNanos = System.nanoTime();
     }
 
     public static <T> Success successful(T data) {
@@ -29,7 +28,7 @@ import java.util.Map;
     @JsonProperty
     public Map<String, ?> meta() {
         return ImmutableMap.<String, Object>of(
-                "response_time_ms", stopwatch.elapsedMillis()
+                "response_time_ms", TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTimeNanos, TimeUnit.NANOSECONDS)
         );
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
         <repository>
             <snapshots>
@@ -39,13 +39,13 @@
             </snapshots>
             <id>central</id>
             <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
         <pluginRepository>
             <snapshots>
@@ -53,7 +53,7 @@
             </snapshots>
             <id>central</id>
             <name>bintray-plugins</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
See [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988) and [JENKINS-66299](https://issues.jenkins.io/browse/JENKINS-66299). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

### `Stopwatch`

This plugin has been identified as using the `com.google.common.base.Stopwatch` API, which has changed between Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/base/Stopwatch.html) and [latest](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/base/Stopwatch.html). The following methods exist in Guava 11.0.1 but not latest:

 * `Stopwatch#elapsedMillis()`
 * `Stopwatch#elapsedTime(TimeUnit desiredUnit)`
 * `Stopwatch#toString(int significantDigits)`

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. In this PR we migrate away from the `Stopwatch` API and use `System#nanoTime` directly.

### `Objects#toStringHelper`

This plugin has been identified as using the `com.google.common.base.Objects#toStringHelper` method, which existed in Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/base/Objects.html) but was [removed in later versions](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/base/Objects.html).

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. In this PR we migrate away from `Objects#toStringHelper` and rewrite the code to use the native functionality provided by the Java Platform.