### PR TITLE
Remove PowerMock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/build-monitor-acceptance/pom.xml
+++ b/build-monitor-acceptance/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -20,11 +21,10 @@
         <encoding>UTF-8</encoding>
         <serenity.version>2.4.51</serenity.version>
         <aether.version>1.0.0.v20140518</aether.version>
+        <bytebuddy.version>1.11.19</bytebuddy.version>
 
         <webdriver.driver>chrome</webdriver.driver>
         <browserstack.url/>
-        <enforcer.skip>true</enforcer.skip>
-        <spotbugs.skip>true</spotbugs.skip>
     </properties>
 
     <profiles>
@@ -68,6 +68,57 @@
             </build>
         </profile>
     </profiles>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- TODO remove when minimum Jenkins core baseline is 2.321 or higher -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>31.0.1-jre</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.inject</groupId>
+                <artifactId>guice</artifactId>
+                <version>5.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.thoughtworks.xstream</groupId>
+                <artifactId>xstream</artifactId>
+                <version>1.4.17</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+                <version>3.8.0</version>
+            </dependency>
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>2.10.5</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>${bytebuddy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${bytebuddy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.12.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.13</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -116,11 +167,6 @@
             <artifactId>maven-aether-provider</artifactId>
             <version>3.2.5</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.5</version>
-        </dependency>
 
         <!-- serenity -->
         <dependency>
@@ -146,15 +192,10 @@
         </dependency>
         <!-- / serenity -->
 
-        <!-- TODO remove when minimum Jenkins core baseline is 2.321 or higher -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
-        </dependency>
         <dependency>
             <groupId>org.jdeferred</groupId>
             <artifactId>jdeferred-core</artifactId>
+            <version>1.2.6</version>
         </dependency>
 
         <dependency>
@@ -165,15 +206,11 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <version>1.7.19</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/build-monitor-plugin/pom.xml
+++ b/build-monitor-plugin/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -81,11 +82,28 @@
         </repository>
     </distributionManagement>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>1013.vf8058992a042</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>20210307</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.12</version>
+            <version>1.9.13</version>
         </dependency>
 
         <dependency>
@@ -216,20 +234,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -242,26 +248,6 @@
                 <exclusion>
                     <groupId>net.sourceforge.htmlunit</groupId>
                     <artifactId>htmlunit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <!-- Because Jenkins relies on global objects and static methods. A lot. -->
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>1.6.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>1.6.5</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.objenesis</groupId>
-                    <artifactId>objenesis</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugin/assetbundler/PathToAssetTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugin/assetbundler/PathToAssetTest.java
@@ -8,8 +8,8 @@ import org.junit.rules.ExpectedException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class PathToAssetTest {
 

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorDescriptorTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorDescriptorTest.java
@@ -11,8 +11,8 @@ import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacti
 import static hudson.util.FormValidation.Kind.ERROR;
 import static hudson.util.FormValidation.Kind.OK;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class BuildMonitorDescriptorTest {
 

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/installation/BuildMonitorInstallationTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/installation/BuildMonitorInstallationTest.java
@@ -3,10 +3,13 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.installation;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade.StaticJenkinsAPIs;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class BuildMonitorInstallationTest {
     public static final String PUBLIC_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlEPjwjG6Q3ILlr91qlSxvvys046hUrhFmc8ibz9WvWEJKVs5dS/mCnRV4QFg4w3qoCH2lzuoSNHB7tWBYQXj1ZtbDiwjnFNYw1TyZBL43m2bRYQGjpcvHAUB6u07C7mmoehpaYoFkpJbLEYEGXsKV/0bY22n00cZHwoTGl5biGVX8gvNKq604pK97jdVuBNZeXiOMXS00Yrwv8tgWeRDIUhUCO8T4rj0bBULh1Pyg/aJBsts7z5RydB+Nb5OZfAfaklVTpFld+ZHMjt0Q7VYhkMkbBD+ZFRkHvRNqg2q7wdQFScGGx7G2RstUtcIPv5Ga36fj1okDU6c2vyPHErTuwIDAQAB";

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/pipeline/BreadthFirstNodeTraversalTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/pipeline/BreadthFirstNodeTraversalTest.java
@@ -7,9 +7,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertThat;
 
 public class BreadthFirstNodeTraversalTest {
     @Test

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/pipeline/PipelineHelperTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/pipeline/PipelineHelperTest.java
@@ -5,46 +5,42 @@ import hudson.Plugin;
 import hudson.model.AbstractBuild;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class, WorkflowRun.class})
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
 public class PipelineHelperTest {
-
-    @Mock
-    private Jenkins jenkins;
-
-    @Mock
-    private Plugin mockedPipeline;
-
-    private WorkflowRun workflowRun;
-
-    @Mock
-    private AbstractBuild abstractBuild;
-
-    @Before
-    public void setup() {
-        PowerMockito.mockStatic(Jenkins.class);
-        workflowRun = PowerMockito.mock(WorkflowRun.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
-        PowerMockito.when(jenkins.getPlugin("workflow-aggregator")).thenReturn(mockedPipeline);
-    }
 
     @Test
     public void isWorkflowRun() {
-        Assert.assertTrue(PipelineHelper.isWorkflowRun(workflowRun, new StaticJenkinsAPIs()));
+        try (MockedStatic<Jenkins> mockedJenkins = mockStatic(Jenkins.class)) {
+            Jenkins jenkins = createMockJenkins(mockedJenkins);
+            Plugin mockedPipeline = mock(Plugin.class);
+            WorkflowRun workflowRun = mock(WorkflowRun.class);
+            when(jenkins.getPlugin("workflow-aggregator")).thenReturn(mockedPipeline);
+
+            assertTrue(PipelineHelper.isWorkflowRun(workflowRun, new StaticJenkinsAPIs()));
+        }
     }
 
     @Test
     public void isNotWorkflowRun() {
-        Assert.assertFalse(PipelineHelper.isWorkflowRun(abstractBuild, new StaticJenkinsAPIs()));
+        try (MockedStatic<Jenkins> mockedJenkins = mockStatic(Jenkins.class)) {
+            createMockJenkins(mockedJenkins);
+            AbstractBuild abstractBuild = mock(AbstractBuild.class);
+
+            assertFalse(PipelineHelper.isWorkflowRun(abstractBuild, new StaticJenkinsAPIs()));
+        }
     }
 
+    private Jenkins createMockJenkins(MockedStatic<Jenkins> mockedJenkins) {
+        Jenkins jenkins = mock(Jenkins.class);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+        return jenkins;
+    }
 }

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildViewTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildViewTest.java
@@ -1,42 +1,35 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel;
 
 import jenkins.model.Jenkins;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
 
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.a;
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.build;
-import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.withDefaultConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class})
 public class BuildViewTest {
 
     private static final String theName = "1.5+build.3";
 
-    @Mock
-    private Jenkins jenkins;
-
-    @Before
-    public void setup() {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
-    }
-
-    private BuildViewModel view;
-
     @Test
     public void should_know_the_name_of_the_job_its_based_on() {
-        view = BuildView.of(a(build().hasName(theName)));
+        try (MockedStatic<Jenkins> mockedJenkins = mockStatic(Jenkins.class)) {
+            createMockJenkins(mockedJenkins);
 
-        assertThat(view.name(), is(theName));
-        assertThat(view.toString(), is(theName));
+            BuildViewModel view = BuildView.of(a(build().hasName(theName)));
+
+            assertThat(view.name(), is(theName));
+            assertThat(view.toString(), is(theName));
+        }
+    }
+
+    private Jenkins createMockJenkins(MockedStatic<Jenkins> mockedJenkins) {
+        Jenkins jenkins = mock(Jenkins.class);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+        return jenkins;
     }
 }

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewTest.java
@@ -2,13 +2,10 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel;
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.facade.RelativeLocation;
 import jenkins.model.Jenkins;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
 
 import java.util.List;
 
@@ -16,17 +13,19 @@ import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacti
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.*;
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.TimeMachine.currentTime;
 import static hudson.model.Result.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Jan Molak
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class})
 public class JobViewTest {
 
     private static final String theName = "some-TLAs-followed-by-a-project-name";
@@ -35,13 +34,19 @@ public class JobViewTest {
     private RelativeLocation relativeLocation = mock(RelativeLocation.class); // TODO recipe builder
     private JobView view;
 
-    @Mock
+    private MockedStatic<Jenkins> mockedJenkins;
     private Jenkins jenkins;
 
     @Before
     public void setup() {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins = mockStatic(Jenkins.class);
+        jenkins = mock(Jenkins.class);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+    }
+
+    @After
+    public void tearDown() {
+        mockedJenkins.close();
     }
 
     /*

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeClaimedTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeClaimedTest.java
@@ -2,37 +2,40 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
 import jenkins.model.Jenkins;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
 
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.*;
 import static hudson.model.Result.FAILURE;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class})
 public class CanBeClaimedTest {
     private JobView job;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    @Mock
+    private MockedStatic<Jenkins> mockedJenkins;
     private Jenkins jenkins;
 
     @Before
     public void setup() {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins = mockStatic(Jenkins.class);
+        jenkins = mock(Jenkins.class);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+    }
+
+    @After
+    public void tearDown() {
+        mockedJenkins.close();
     }
 
     @Test

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeDiagnosedForProblemsTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/CanBeDiagnosedForProblemsTest.java
@@ -3,31 +3,34 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.Config.BuildFailureAnalyzerDisplayedField;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
 import jenkins.model.Jenkins;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
 
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.*;
 import static hudson.model.Result.FAILURE;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class})
 public class CanBeDiagnosedForProblemsTest {
     private JobView job;
 
-    @Mock
+    private MockedStatic<Jenkins> mockedJenkins;
     private Jenkins jenkins;
 
     @Before
     public void setup() {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins = mockStatic(Jenkins.class);
+        jenkins = mock(Jenkins.class);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+    }
+
+    @After
+    public void tearDown() {
+        mockedJenkins.close();
     }
 
     @Test

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasBadgesBadgePluginTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasBadgesBadgePluginTest.java
@@ -2,39 +2,40 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
 import jenkins.model.Jenkins;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
 
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.*;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
-import java.net.URL;
-
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class, URL.class})
 public class HasBadgesBadgePluginTest {
     private JobView job;
     
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    @Mock
+    private MockedStatic<Jenkins> mockedJenkins;
     private Jenkins jenkins;
 
     @Before
     public void setup() {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins = mockStatic(Jenkins.class);
+        jenkins = mock(Jenkins.class);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+    }
+
+    @After
+    public void tearDown() {
+        mockedJenkins.close();
     }
 
     @Test

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingFailedBuildDetailsTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingFailedBuildDetailsTest.java
@@ -3,31 +3,34 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features.headline.HeadlineConfig;
 import jenkins.model.Jenkins;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
 
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class})
 public class HasHeadlineShowingFailedBuildDetailsTest {
 
     private JobView view;
 
-    @Mock
+    private MockedStatic<Jenkins> mockedJenkins;
     private Jenkins jenkins;
 
     @Before
     public void setup() {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins = mockStatic(Jenkins.class);
+        jenkins = mock(Jenkins.class);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+    }
+
+    @After
+    public void tearDown() {
+        mockedJenkins.close();
     }
 
     @Test

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingFixedBuildDetailsTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingFixedBuildDetailsTest.java
@@ -3,32 +3,35 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features.headline.HeadlineConfig;
 import jenkins.model.Jenkins;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
 
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class})
 public class HasHeadlineShowingFixedBuildDetailsTest {
 
     private JobView view;
 
-    @Mock
+    private MockedStatic<Jenkins> mockedJenkins;
     private Jenkins jenkins;
 
     @Before
     public void setup() {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins = mockStatic(Jenkins.class);
+        jenkins = mock(Jenkins.class);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+    }
+
+    @After
+    public void tearDown() {
+        mockedJenkins.close();
     }
 
     @Test

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingRunningBuildDetailsTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineShowingRunningBuildDetailsTest.java
@@ -3,32 +3,35 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features.headline.HeadlineConfig;
 import jenkins.model.Jenkins;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
 
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class})
 public class HasHeadlineShowingRunningBuildDetailsTest {
 
     private JobView view;
 
-    @Mock
+    private MockedStatic<Jenkins> mockedJenkins;
     private Jenkins jenkins;
 
     @Before
     public void setup() {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins = mockStatic(Jenkins.class);
+        jenkins = mock(Jenkins.class);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+    }
+
+    @After
+    public void tearDown() {
+        mockedJenkins.close();
     }
 
     @Test

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineWhichShowsNothingTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/HasHeadlineWhichShowsNothingTest.java
@@ -5,8 +5,8 @@ import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features.headli
 import org.junit.Test;
 
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyString;
-import static org.junit.Assert.assertThat;
 
 public class HasHeadlineWhichShowsNothingTest {
     private JobView view;

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/KnowsCurrentBuildsDetailsTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/KnowsCurrentBuildsDetailsTest.java
@@ -4,35 +4,38 @@ import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features.KnowsCurrentBuildsDetails.CurrentBuild;
 
 import jenkins.model.Jenkins;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
 
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.*;
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.TimeMachine.assumeThat;
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.TimeMachine.currentTime;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
 import java.util.Date;
 import java.util.List;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class})
 public class KnowsCurrentBuildsDetailsTest {
     private JobView view;
 
-    @Mock
+    private MockedStatic<Jenkins> mockedJenkins;
     private Jenkins jenkins;
 
     @Before
     public void setup() {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins = mockStatic(Jenkins.class);
+        jenkins = mock(Jenkins.class);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+    }
+
+    @After
+    public void tearDown() {
+        mockedJenkins.close();
     }
 
     @Test

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/KnowsLastCompletedBuildDetailsTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/features/KnowsLastCompletedBuildDetailsTest.java
@@ -2,32 +2,35 @@ package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.features;
 
 import com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView;
 import jenkins.model.Jenkins;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
 
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.Sugar.*;
 import static com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar.TimeMachine.currentTime;
 import static hudson.model.Result.SUCCESS;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class})
 public class KnowsLastCompletedBuildDetailsTest {
     private JobView view;
 
-    @Mock
+    private MockedStatic<Jenkins> mockedJenkins;
     private Jenkins jenkins;
 
     @Before
     public void setup() {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        mockedJenkins = mockStatic(Jenkins.class);
+        jenkins = mock(Jenkins.class);
+        mockedJenkins.when(Jenkins::getInstance).thenReturn(jenkins);
+    }
+
+    @After
+    public void tearDown() {
+        mockedJenkins.close();
     }
 
     @Test

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/readability/ListerTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/readability/ListerTest.java
@@ -6,8 +6,8 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class ListerTest {
 

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/BadgeBadgePluginRecipe.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/BadgeBadgePluginRecipe.java
@@ -4,6 +4,7 @@ import com.jenkinsci.plugins.badge.action.BadgeAction;
 
 import java.util.function.Supplier;
 
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -19,13 +20,13 @@ public class BadgeBadgePluginRecipe implements Supplier<BadgeAction> {
 
     public BadgeBadgePluginRecipe withText(String text) throws Exception {
         when(badge.getIconPath()).thenReturn(null);
-        when(badge.getText()).thenReturn(text);
+        lenient().when(badge.getText()).thenReturn(text);
         return this;
     }
 
     public BadgeBadgePluginRecipe withIcon(String icon, String text) throws Exception {
         when(badge.getIconPath()).thenReturn(icon);
-        when(badge.getText()).thenReturn(text);
+        lenient().when(badge.getText()).thenReturn(text);
         return this;
     }
 

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/JobStateRecipe.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/syntacticsugar/JobStateRecipe.java
@@ -1,22 +1,20 @@
 package com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.syntacticsugar;
 
 import hudson.model.AbstractBuild;
-import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.ViewJob;
 import hudson.util.RunList;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Stack;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Jan Molak
@@ -31,11 +29,11 @@ public class JobStateRecipe implements Supplier<Job<?,?>> {
         job = mock(Job.class);
         runList = mock(RunList.class);
 
-        when(job.isBuildable()).thenReturn(Boolean.TRUE);
+        lenient().when(job.isBuildable()).thenReturn(Boolean.TRUE);
     }
 
     public JobStateRecipe withName(String name) {
-        when(job.getName()).thenReturn(name);
+        lenient().when(job.getName()).thenReturn(name);
 
         // The name of the job also defines its URL, that's why the stub for getUrl() is defined here as well.
         // You could argue, that 'withUrl' could be a separate method on the builder,
@@ -45,20 +43,14 @@ public class JobStateRecipe implements Supplier<Job<?,?>> {
     }
 
     private JobStateRecipe withShortUrl(String url) {
-        when(job.getShortUrl()).thenReturn(url);
-
-        // This might not necessarily belong here,
-        // but I don't need to introduce the concept of a parent anywhere else yet.
-        ItemGroup parent = mock(ItemGroup.class);
-        when(parent.getUrl()).thenReturn("job/");
-        when(job.getParent()).thenReturn(parent);
+        lenient().when(job.getShortUrl()).thenReturn(url);
 
         return this;
     }
 
     public JobStateRecipe withDisplayName(String name) {
-        when(job.getDisplayNameOrNull()).thenReturn(name);
-        when(job.getDisplayName()).thenReturn(name);
+        lenient().when(job.getDisplayNameOrNull()).thenReturn(name);
+        lenient().when(job.getDisplayName()).thenReturn(name);
 
         return this;
     }
@@ -101,19 +93,19 @@ public class JobStateRecipe implements Supplier<Job<?,?>> {
             earliestBuild = buildHistory.pop();
             earlierBuild  = buildHistory.peek();
 
-            when(earlierBuild.getPreviousBuild()).thenReturn(earliestBuild);
+            lenient().when(earlierBuild.getPreviousBuild()).thenReturn(earliestBuild);
         }
 
         // pick the first build from the build history and make it the "last build"
         if (buildHistory.size() == 1) {
-        	doReturn(buildHistory.pop()).when(job).getLastBuild();
+            lenient().doReturn(buildHistory.pop()).when(job).getLastBuild();
         }
         
         // mock the necessary methods to get the currentBuilds
         // it will return the full list so make sure it contains only building builds
-        doReturn(runList).when(job).getNewBuilds();
-        doReturn(runList).when(runList).filter(any(Predicate.class));
-        doReturn(allBuilds.iterator()).when(runList).iterator();
+        lenient().doReturn(runList).when(job).getNewBuilds();
+        lenient().doReturn(runList).when(runList).filter(any(Predicate.class));
+        lenient().doReturn(allBuilds.iterator()).when(runList).iterator();
 
         return job;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -58,28 +58,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.289.x</artifactId>
-                <version>987.v4ade2e49fe70</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>antlr</groupId>
-                <artifactId>antlr</artifactId>
-                <version>2.7.7</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jdeferred</groupId>
-                <artifactId>jdeferred-core</artifactId>
-                <version>1.2.4</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>1.7.19</version>
-            </dependency>
-            <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-io</artifactId>
                 <version>${jetty.version}</version>
@@ -123,22 +101,6 @@
                 <groupId>org.eclipse.jetty.websocket</groupId>
                 <artifactId>websocket-server</artifactId>
                 <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>1.3</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>2.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.json</groupId>
-                <artifactId>json</artifactId>
-                <version>20210307</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This PR cleans up the Maven build and removes the use of PowerMock. PowerMock doesn't work with Java 11+ and has been removed from Jenkins core and recent versions of the plugin parent POM in favor of `mockito-inline`, so adapt this plugin to conform to the current recommendation from the Jenkins core team.