### PR TITLE
Improve acceptance tests speed

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,13 +25,13 @@ jobs:
           distribution: 'adopt'
           cache: 'maven'
 
-      - name: Cache eclipse plugins
+      - name: Cache jenkins plugins
         uses: actions/cache@v2
         with:
           path: build-monitor-acceptance/plugin_cache
-          key: eclipse-plugins-${{ hashFiles('build-monitor-acceptance/pom.xml') }}
+          key: jenkins-plugins-${{ hashFiles('build-monitor-acceptance/pom.xml') }}
           restore-keys: |
-            eclipse-plugins-
+            jenkins-plugins-
 
       - name: Setup git (master only)
         uses: ./.github/actions/setup-git

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,6 +25,14 @@ jobs:
           distribution: 'adopt'
           cache: 'maven'
 
+      - name: Cache eclipse plugins
+        uses: actions/cache@v2
+        with:
+          path: build-monitor-acceptance/plugin_cache
+          key: eclipse-plugins-${{ hashFiles('build-monitor-acceptance/pom.xml') }}
+          restore-keys: |
+            eclipse-plugins-
+
       - name: Setup git (master only)
         uses: ./.github/actions/setup-git
         if: github.ref == 'refs/heads/master'

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ work
 
 node
 node_modules
+plugin_cache
 
 use-node
 .DS_Store

--- a/build-monitor-acceptance/pom.xml
+++ b/build-monitor-acceptance/pom.xml
@@ -26,6 +26,7 @@
 
         <webdriver.driver>chrome</webdriver.driver>
         <browserstack.url/>
+        <plugins.cache>${project.build.directory}/plugin_cache</plugins.cache>
     </properties>
 
     <profiles>
@@ -239,6 +240,63 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
+                <version>2.1.1</version>
+                <executions>
+                    <execution>
+                        <id>download-jenkins-plugins</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <source>
+                                <![CDATA[
+                                    def plugins = properties.plugins.split(",")
+                                    def jenkinsVersions = properties.jenkins_versions.split(",") 
+
+                                    def destDir = new java.io.File(properties.dest_dir)
+
+                                    for (def jenkinsVersion : jenkinsVersions) {
+                                        def jenkinsVersionDestDir = new java.io.File(destDir, jenkinsVersion)
+
+                                        for (def pluginId : plugins) {
+                                            def pluginDest = new java.io.File(jenkinsVersionDestDir, pluginId)
+                                            pluginDest.mkdirs()
+                                            def args = [
+                                                "--jenkins-version", jenkinsVersion,
+                                                "--plugins", pluginId,
+                                                "--plugin-download-directory", pluginDest,
+                                            ] as String[]
+                                            println "Cache plugin ${pluginId} for jenkins version ${jenkinsVersion}"
+                                            io.jenkins.tools.pluginmanager.cli.Main.main(args)
+                                        }
+                                    }
+                                ]]>
+                            </source>
+                            <properties>
+                                <plugins>build-monitor-plugin,description-setter,workflow-aggregator,badge,cloudbees-folder,external-monitor-job,build-failure-analyzer,claim</plugins>
+                                <jenkins_versions>${jenkins.version},${jenkins.latest.version}</jenkins_versions>
+                                <dest_dir>${plugins.cache}</dest_dir>
+                            </properties>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-all</artifactId>
+                        <version>2.4.21</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.jenkins.plugin-management</groupId>
+                        <artifactId>plugin-management-cli</artifactId>
+                        <version>2.11.1</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <excludes>
@@ -259,6 +317,7 @@
                         <BROWSER>htmlunit</BROWSER>
                         <JENKINS_VERSIONS>${jenkins.version},${jenkins.latest.version}</JENKINS_VERSIONS>
                         <PLUGINS_DIR>../build-monitor-plugin/target</PLUGINS_DIR>
+                        <PLUGINS_CACHE>${plugins.cache}</PLUGINS_CACHE>
                         <NEVER_REPLACE_EXISTING_PLUGINS>false</NEVER_REPLACE_EXISTING_PLUGINS>
                     </environmentVariables>
                     <forkCount>2</forkCount>

--- a/build-monitor-acceptance/pom.xml
+++ b/build-monitor-acceptance/pom.xml
@@ -273,7 +273,7 @@
                                 ]]>
                             </source>
                             <properties>
-                                <plugins>build-monitor-plugin,description-setter,workflow-aggregator,badge,cloudbees-folder,external-monitor-job,build-failure-analyzer,claim</plugins>
+                                <plugins>description-setter,workflow-aggregator,badge,cloudbees-folder,external-monitor-job,build-failure-analyzer,claim</plugins>
                                 <jenkins_versions>${jenkins.version},${jenkins.latest.version}</jenkins_versions>
                                 <dest_dir>${plugins.cache}</dest_dir>
                                 <local_repo>${settings.localRepository}</local_repo>

--- a/build-monitor-acceptance/pom.xml
+++ b/build-monitor-acceptance/pom.xml
@@ -26,7 +26,7 @@
 
         <webdriver.driver>chrome</webdriver.driver>
         <browserstack.url/>
-        <plugins.cache>${project.build.directory}/plugin_cache</plugins.cache>
+        <plugins.cache>${project.basedir}/plugin_cache</plugins.cache>
     </properties>
 
     <profiles>
@@ -243,6 +243,11 @@
                         <configuration>
                             <source>
                                 <![CDATA[
+                                    def skipTests = Boolean.valueOf(properties.skipTests)
+                                    def skipITs = Boolean.valueOf(properties.skipITs)
+                                    if (skipTests || skipITs)
+                                        return
+                                    
                                     def plugins = properties.plugins.split(",")
                                     def jenkinsVersions = properties.jenkins_versions.split(",") 
 
@@ -258,6 +263,8 @@
                                                 "--jenkins-version", jenkinsVersion,
                                                 "--plugins", pluginId,
                                                 "--plugin-download-directory", pluginDest,
+                                                "--war", "${properties.local_repo}/org/jenkins-ci/main/jenkins-war/${jenkinsVersion}/jenkins-war-${jenkinsVersion}.war",
+                                                //"--list",
                                             ] as String[]
                                             println "Cache plugin ${pluginId} for jenkins version ${jenkinsVersion}"
                                             io.jenkins.tools.pluginmanager.cli.Main.main(args)
@@ -269,6 +276,9 @@
                                 <plugins>build-monitor-plugin,description-setter,workflow-aggregator,badge,cloudbees-folder,external-monitor-job,build-failure-analyzer,claim</plugins>
                                 <jenkins_versions>${jenkins.version},${jenkins.latest.version}</jenkins_versions>
                                 <dest_dir>${plugins.cache}</dest_dir>
+                                <local_repo>${settings.localRepository}</local_repo>
+                                <skipTests>${skipTests}</skipTests>
+                                <skipITs>${skipITs}</skipITs>
                             </properties>
                         </configuration>
                     </execution>

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/InstallPlugins.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/InstallPlugins.java
@@ -7,6 +7,10 @@ public class InstallPlugins {
         return new InstallPluginsFromDisk(locations);
     }
 
+    public static InstallPluginsFromDisk fromCache(Path pluginCache, String... pluginIDs) {
+        return new InstallPluginsFromDisk(pluginCache, pluginIDs);
+    }
+
     public static InstallPluginsFromUpdateCenter fromUpdateCenter(String... pluginIDs) {
         return new InstallPluginsFromUpdateCenter(pluginIDs);
     }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/InstallPluginsFromDisk.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/InstallPluginsFromDisk.java
@@ -7,8 +7,6 @@ import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -91,12 +89,7 @@ public class InstallPluginsFromDisk implements ApplicativeTestRule<JenkinsInstan
             private List<Path> getDirectoryPlugins(Path location) {
                 List<Path> plugins = new ArrayList<>();
                 
-                String[] files = location.toFile().list(new FilenameFilter() {
-                    @Override
-                    public boolean accept(File dir, String name) {
-                        return name.endsWith(".jpi") || name.endsWith(".hpi");
-                    }
-                });
+                String[] files = location.toFile().list((dir, name) -> name.endsWith(".jpi") || name.endsWith(".hpi"));
                 
                 if (files != null ) {
                     for (String file : files ) {

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/InstallPluginsFromDisk.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/rules/InstallPluginsFromDisk.java
@@ -7,9 +7,13 @@ import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,10 +22,20 @@ import static java.util.Arrays.asList;
 public class InstallPluginsFromDisk implements ApplicativeTestRule<JenkinsInstance> {
     private static final Logger Log = LoggerFactory.getLogger(InstallPluginsFromDisk.class);
 
+    private final Path pluginsCache;
+    private final List<String> pluginIDs;
     private final List<Path> pluginsToInstall;
 
     public InstallPluginsFromDisk(Path... pluginsToInstall) {
+        this.pluginsCache = null;
+        this.pluginIDs = asList();
         this.pluginsToInstall = asList(pluginsToInstall);
+    }
+
+    public InstallPluginsFromDisk(Path pluginsCache, String... pluginIDs) {
+        this.pluginsCache = pluginsCache;
+        this.pluginIDs = asList(pluginIDs);
+        this.pluginsToInstall = asList();
     }
 
     @Override
@@ -30,15 +44,24 @@ public class InstallPluginsFromDisk implements ApplicativeTestRule<JenkinsInstan
             @Override
             protected void starting(Description description) {
                 Path pluginsDir = jenkins.home().resolve("plugins");
-                String plugins  = pluginsToInstall.stream().map(Object::toString).collect(Collectors.joining(", "));
+                List<Path> plugins;
+                if (pluginsCache == null) {
+                    Log.info("Installing {} into {}", pluginsToInstall.stream().map(Object::toString).collect(Collectors.joining(", ")), pluginsDir);
+                    plugins = pluginsToInstall;
+                } else {
+                    Log.info("Installing plugins {} into {}", pluginIDs, pluginsDir);
+                    plugins = getPluginsFromCache();
+                }
 
-                Log.info("Installing {} into {}", plugins, pluginsDir);
+                copyPlugins(plugins, pluginsDir);
+            }
 
+            protected void copyPlugins(List<Path> plugins, Path pluginsDir) {
                 try {
-                    Files.createDirectories(jenkins.home().resolve("plugins"));
+                    Files.createDirectories(pluginsDir);
 
-                    for (Path plugin : pluginsToInstall) {
-                        Files.copy(existing(plugin), pluginsDir.resolve(plugin.getFileName()));
+                    for (Path plugin : plugins) {
+                        Files.copy(existing(plugin), pluginsDir.resolve(plugin.getFileName()), StandardCopyOption.REPLACE_EXISTING);
                     }
                 } catch (IOException e) {
                     throw new RuntimeException(String.format("Couldn't install '%s' under '%s'", plugins, pluginsDir.toAbsolutePath()));
@@ -51,6 +74,37 @@ public class InstallPluginsFromDisk implements ApplicativeTestRule<JenkinsInstan
                 }
 
                 return plugin;
+            }
+            
+            private List<Path> getPluginsFromCache() {
+                List<Path> plugins = new ArrayList<>();
+                
+                Path jenkinsVersionPluginCache = pluginsCache.resolve(System.getProperty("jenkins.version"));
+                
+                for (String pluginDir : pluginIDs) {
+                    plugins.addAll(getDirectoryPlugins(jenkinsVersionPluginCache.resolve(pluginDir)));
+                }
+                
+                return plugins;
+            }
+            
+            private List<Path> getDirectoryPlugins(Path location) {
+                List<Path> plugins = new ArrayList<>();
+                
+                String[] files = location.toFile().list(new FilenameFilter() {
+                    @Override
+                    public boolean accept(File dir, String name) {
+                        return name.endsWith(".jpi") || name.endsWith(".hpi");
+                    }
+                });
+                
+                if (files != null ) {
+                    for (String file : files ) {
+                        plugins.add(location.resolve(file));
+                    }
+                }
+                
+                return plugins;
             }
         };
     }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/build_steps/GroovyScriptThat.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/tasks/configuration/build_steps/GroovyScriptThat.java
@@ -2,5 +2,5 @@ package net.serenitybdd.screenplay.jenkins.tasks.configuration.build_steps;
 
 public class GroovyScriptThat {
     public static final GroovyScript Adds_A_Badge = GroovyScript.that("Adds a badge")
-            .definedAs("manager.addShortText('Coverage', 'black', 'repeating-linear-gradient(45deg, yellow, yellow 10px, Orange 10px, Orange 20px)', '0px', 'white')");
+            .definedAs("addShortText(text:'Coverage', color:'black', background:'repeating-linear-gradient(45deg, yellow, yellow 10px, Orange 10px, Orange 20px)', border: 0, borderColor:'white')");
 }

--- a/build-monitor-acceptance/src/test/java/features/BuilMonitorAcceptanceTest.java
+++ b/build-monitor-acceptance/src/test/java/features/BuilMonitorAcceptanceTest.java
@@ -10,7 +10,10 @@ import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -19,9 +22,18 @@ public abstract class BuilMonitorAcceptanceTest {
 
     @Managed public WebDriver browser;
 
-    @Rule public JenkinsInstance jenkins = JenkinsSandbox.configure().afterStart(jenkinsAfterStartRules()).create();
+    @Rule public JenkinsInstance jenkins = JenkinsSandbox.configure()
+            .beforeStart(jenkinsBeforeStartRules())
+            .afterStart(jenkinsAfterStartRules())
+            .create();
     
-    protected abstract List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsAfterStartRules();
+    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsBeforeStartRules() {
+        return Arrays.asList();
+    }
+    
+    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsAfterStartRules() {
+        return Arrays.asList();
+    }
 
 
     public static Collection<Object[]> testData(){
@@ -37,5 +49,9 @@ public abstract class BuilMonitorAcceptanceTest {
     
     protected BuilMonitorAcceptanceTest(String jenkinsVersion) {
         System.setProperty("jenkins.version", jenkinsVersion);
+    }
+    
+    protected Path getpluginsCache() {
+        return Paths.get(System.getenv("PLUGINS_CACHE"));
     }
 }

--- a/build-monitor-acceptance/src/test/java/features/BuildMonitorShouldBeEasyToSetUp.java
+++ b/build-monitor-acceptance/src/test/java/features/BuildMonitorShouldBeEasyToSetUp.java
@@ -2,8 +2,6 @@ package features;
 
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.ProjectWidget;
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.HaveABuildMonitorViewCreated;
-import net.serenitybdd.integration.jenkins.JenkinsInstance;
-import net.serenitybdd.integration.jenkins.environment.rules.ApplicativeTestRule;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
 import net.serenitybdd.screenplay.jenkins.HaveAProjectCreated;
@@ -20,9 +18,7 @@ import static net.serenitybdd.screenplay.GivenWhenThen.then;
 import static net.serenitybdd.screenplay.GivenWhenThen.when;
 import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isCurrentlyVisible;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 public class BuildMonitorShouldBeEasyToSetUp extends BuilMonitorAcceptanceTest {
 
@@ -30,10 +26,6 @@ public class BuildMonitorShouldBeEasyToSetUp extends BuilMonitorAcceptanceTest {
 
     public BuildMonitorShouldBeEasyToSetUp(String jenkinsVersion) {
         super(jenkinsVersion);
-    }
-
-    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsAfterStartRules() {
-        return Arrays.asList();
     }
 
     @TestData

--- a/build-monitor-acceptance/src/test/java/features/ProjectStatusShouldBeEasyToDetermine.java
+++ b/build-monitor-acceptance/src/test/java/features/ProjectStatusShouldBeEasyToDetermine.java
@@ -2,8 +2,6 @@ package features;
 
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.ProjectWidget;
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.HaveABuildMonitorViewCreated;
-import net.serenitybdd.integration.jenkins.JenkinsInstance;
-import net.serenitybdd.integration.jenkins.environment.rules.ApplicativeTestRule;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
 import net.serenitybdd.screenplay.jenkins.HaveAFailingProjectCreated;
@@ -19,9 +17,7 @@ import static com.smartcodeltd.jenkinsci.plugins.build_monitor.model.ProjectStat
 import static com.smartcodeltd.jenkinsci.plugins.build_monitor.model.ProjectStatus.Successful;
 import static net.serenitybdd.screenplay.GivenWhenThen.*;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 public class ProjectStatusShouldBeEasyToDetermine extends BuilMonitorAcceptanceTest {
 
@@ -29,10 +25,6 @@ public class ProjectStatusShouldBeEasyToDetermine extends BuilMonitorAcceptanceT
 
     public ProjectStatusShouldBeEasyToDetermine(String jenkinsVersion) {
         super(jenkinsVersion);
-    }
-
-    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsAfterStartRules() {
-        return Arrays.asList();
     }
 
     @TestData

--- a/build-monitor-acceptance/src/test/java/features/ShouldDescribeEachProject.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldDescribeEachProject.java
@@ -33,8 +33,8 @@ public class ShouldDescribeEachProject extends BuilMonitorAcceptanceTest {
         super(jenkinsVersion);
     }
 
-    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsAfterStartRules() {
-        return Arrays.asList(InstallPlugins.fromUpdateCenter("description-setter"));
+    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsBeforeStartRules() {
+        return Arrays.asList(InstallPlugins.fromCache(getpluginsCache(), "workflow-aggregator", "description-setter"));
     }
 
     @TestData

--- a/build-monitor-acceptance/src/test/java/features/ShouldDisplayBadges.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldDisplayBadges.java
@@ -37,8 +37,8 @@ public class ShouldDisplayBadges extends BuilMonitorAcceptanceTest {
         super(jenkinsVersion);
     }
 
-    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsAfterStartRules() {
-        return Arrays.asList(InstallPlugins.fromUpdateCenter("workflow-aggregator", "buildtriggerbadge", "badge", "groovy-postbuild"));
+    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsBeforeStartRules() {
+        return Arrays.asList(InstallPlugins.fromCache(getpluginsCache(), "workflow-aggregator", "badge"));
     }
 
     @TestData

--- a/build-monitor-acceptance/src/test/java/features/ShouldDisplayConcurrentBuilds.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldDisplayConcurrentBuilds.java
@@ -34,8 +34,8 @@ public class ShouldDisplayConcurrentBuilds extends BuilMonitorAcceptanceTest {
         super(jenkinsVersion);
     }
 
-    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsAfterStartRules() {
-        return Arrays.asList(InstallPlugins.fromUpdateCenter("description-setter"));
+    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsBeforeStartRules() {
+        return Arrays.asList(InstallPlugins.fromCache(getpluginsCache(), "workflow-aggregator", "description-setter"));
     }
 
     @TestData

--- a/build-monitor-acceptance/src/test/java/features/ShouldDisplayPipelineStage.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldDisplayPipelineStage.java
@@ -31,8 +31,8 @@ public class ShouldDisplayPipelineStage extends BuilMonitorAcceptanceTest {
         super(jenkinsVersion);
     }
 
-    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsAfterStartRules() {
-        return Arrays.asList(InstallPlugins.fromUpdateCenter("workflow-aggregator"));
+    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsBeforeStartRules() {
+        return Arrays.asList(InstallPlugins.fromCache(getpluginsCache(), "workflow-aggregator"));
     }
 
     @TestData

--- a/build-monitor-acceptance/src/test/java/features/ShouldSupportCloudBeesFolders.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldSupportCloudBeesFolders.java
@@ -32,8 +32,8 @@ public class ShouldSupportCloudBeesFolders extends BuilMonitorAcceptanceTest {
         super(jenkinsVersion);
     }
 
-    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsAfterStartRules() {
-        return Arrays.asList(InstallPlugins.fromUpdateCenter("cloudbees-folder"));
+    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsBeforeStartRules() {
+        return Arrays.asList(InstallPlugins.fromCache(getpluginsCache(), "cloudbees-folder"));
     }
 
     @TestData

--- a/build-monitor-acceptance/src/test/java/features/ShouldSupportExternalProjects.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldSupportExternalProjects.java
@@ -32,8 +32,8 @@ public class ShouldSupportExternalProjects extends BuilMonitorAcceptanceTest {
         super(jenkinsVersion);
     }
 
-    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsAfterStartRules() {
-        return Arrays.asList(InstallPlugins.fromUpdateCenter("external-monitor-job"));
+    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsBeforeStartRules() {
+        return Arrays.asList(InstallPlugins.fromCache(getpluginsCache(), "external-monitor-job"));
     }
 
     @TestData

--- a/build-monitor-acceptance/src/test/java/features/ShouldTellWhatBrokeTheBuild.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldTellWhatBrokeTheBuild.java
@@ -30,8 +30,8 @@ public class ShouldTellWhatBrokeTheBuild extends BuilMonitorAcceptanceTest {
         super(jenkinsVersion);
     }
 
-    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsAfterStartRules() {
-        return Arrays.asList(InstallPlugins.fromUpdateCenter("cloudbees-folder", "build-failure-analyzer"));
+    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsBeforeStartRules() {
+        return Arrays.asList(InstallPlugins.fromCache(getpluginsCache(), "workflow-aggregator", "cloudbees-folder", "build-failure-analyzer"));
     }
 
     @TestData

--- a/build-monitor-acceptance/src/test/java/features/ShouldTellWhoIsFixingTheBrokenBuild.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldTellWhoIsFixingTheBrokenBuild.java
@@ -35,9 +35,13 @@ public class ShouldTellWhoIsFixingTheBrokenBuild extends BuilMonitorAcceptanceTe
         super(jenkinsVersion);
     }
 
+    protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsBeforeStartRules() {
+        return Arrays.asList(InstallPlugins.fromCache(getpluginsCache(), "claim"));
+    }
+
     protected List<? extends ApplicativeTestRule<JenkinsInstance>> jenkinsAfterStartRules() {
         ben = JenkinsUser.named("Ben");
-        return Arrays.asList(InstallPlugins.fromUpdateCenter("claim"), RegisterUserAccount.of(ben));
+        return Arrays.asList(RegisterUserAccount.of(ben));
     }
 
     @TestData

--- a/build-monitor-acceptance/src/test/resources/serenity.conf
+++ b/build-monitor-acceptance/src/test/resources/serenity.conf
@@ -15,7 +15,7 @@ browserstack {
 
 serenity {
   project.name     = "Build Monitor for Jenkins"
-  take.screenshots = AFTER_EACH_STEP
+  take.screenshots = FOR_FAILURES
   test.root        = "features"
   tag.failures     = "true"
   linked.tags      = "issue"


### PR DESCRIPTION
Improve the acceptance tests speed by caching all plugins locally and install them from the cache in each test.
The cache is built using the jenkins plugin-management-cli.
