### PR TITLE
Publish Parent POM during release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -95,3 +95,8 @@ jobs:
             -Dfile=build-monitor-plugin/target/build-monitor-plugin.hpi \
             -DrepositoryId=repo.jenkins-ci.org \
             -Durl=https://repo.jenkins-ci.org/releases/
+          mvn --batch-mode deploy:deploy-file \
+            -DpomFile=pom.xml \
+            -Dfile=pom.xml \
+            -DrepositoryId=repo.jenkins-ci.org \
+            -Durl=https://repo.jenkins-ci.org/releases/


### PR DESCRIPTION
While publishing the artifact the pom references the parent pom.
However, the parent pom is not being published.

This causes problems for people using maven/gradle to resolve the artifact - very common for people using `job dsl plugin` or `gradle jpi plugin`.

This change publishes the parent pom so those users can get dependency resolution to work.

Fixes #373
Fixes JENKINS-43171