### PR TITLE
Publish jar in addition to hpi

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -93,6 +93,8 @@ jobs:
           mvn --batch-mode deploy:deploy-file \
             -DpomFile=build-monitor-plugin/pom.xml \
             -Dfile=build-monitor-plugin/target/build-monitor-plugin.hpi \
+            -Dfiles=build-monitor-plugin/target/build-monitor-plugin.jar \
+            -Dtypes=jar \
             -DrepositoryId=repo.jenkins-ci.org \
             -Durl=https://repo.jenkins-ci.org/releases/
           mvn --batch-mode deploy:deploy-file \


### PR DESCRIPTION
This allows other plugins that depend on this plugin to reference classes without having to first extract the HPI to get to the jar.

Since the GAV coordinates of the JAR are the same as for the HPI, I don't think we need a change to the permissions.