### PR TITLE
Set classifier to empty for jar

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -95,6 +95,7 @@ jobs:
             -Dfile=build-monitor-plugin/target/build-monitor-plugin.hpi \
             -Dfiles=build-monitor-plugin/target/build-monitor-plugin.jar \
             -Dtypes=jar \
+            -Dclassifiers="" \
             -DrepositoryId=repo.jenkins-ci.org \
             -Durl=https://repo.jenkins-ci.org/releases/
           mvn --batch-mode deploy:deploy-file \


### PR DESCRIPTION
This should fix the build broken by https://github.com/jan-molak/jenkins-build-monitor-plugin/pull/524