### PR TITLE
bump serenity from 2.4.51 to 3.2.0

### DIFF
--- a/build-monitor-acceptance/pom.xml
+++ b/build-monitor-acceptance/pom.xml
@@ -19,7 +19,7 @@
         <jenkins.latest.version>2.303.1</jenkins.latest.version>
 
         <encoding>UTF-8</encoding>
-        <serenity.version>2.4.51</serenity.version>
+        <serenity.version>3.2.0</serenity.version>
         <aether.version>1.0.2.v20150114</aether.version>
         <bytebuddy.version>1.12.7</bytebuddy.version>
         <slf4j.version>1.7.35</slf4j.version>
@@ -113,6 +113,12 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+            <!-- Fix RequireUpperBoundDeps -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.21</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/project_widget/ProjectWidgetBuilds.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/project_widget/ProjectWidgetBuilds.java
@@ -14,7 +14,7 @@ public class ProjectWidgetBuilds implements Question<String> {
     public String answeredBy(Actor actor) {
         Target builds     = BuildMonitorDashboard.Project_Widget_Builds.of(projectName);
 
-        return Text.of(builds).viewedBy(actor).resolve();
+        return Text.of(builds).answeredBy(actor);
     }
 
     public ProjectWidgetBuilds(String projectName) {

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/project_widget/ProjectWidgetDetails.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/project_widget/ProjectWidgetDetails.java
@@ -14,7 +14,7 @@ public class ProjectWidgetDetails implements Question<String> {
     public String answeredBy(Actor actor) {
         Target details    = BuildMonitorDashboard.Project_Widget_Details.of(projectName);
 
-        return Text.of(details).viewedBy(actor).resolve();
+        return Text.of(details).answeredBy(actor);
     }
 
     public ProjectWidgetDetails(String projectName) {

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/project_widget/ProjectWidgetInformation.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/project_widget/ProjectWidgetInformation.java
@@ -15,7 +15,7 @@ public class ProjectWidgetInformation implements Question<ProjectInformation> {
     @Override
     public ProjectInformation answeredBy(Actor actor) {
         Target widget     = BuildMonitorDashboard.Project_Widget.of(projectName);
-        String cssClasses = Attribute.of(widget).named("class").viewedBy(actor).asString();
+        String cssClasses = Attribute.of(widget).named("class").answeredBy(actor);
 
         return new ProjectInformation(projectName, ProjectStatus.fromMultiple(cssClasses));
     }

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/project_widget/ProjectWidgetPipelineStages.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/questions/project_widget/ProjectWidgetPipelineStages.java
@@ -14,7 +14,7 @@ public class ProjectWidgetPipelineStages implements Question<String> {
     public String answeredBy(Actor actor) {
         Target details = BuildMonitorDashboard.Project_Widget_Pipeline_Stages.of(projectName);
 
-        return Text.of(details).viewedBy(actor).resolve();
+        return Text.of(details).answeredBy(actor);
     }
 
     public ProjectWidgetPipelineStages(String projectName) {

--- a/build-monitor-acceptance/src/test/resources/serenity.conf
+++ b/build-monitor-acceptance/src/test/resources/serenity.conf
@@ -35,7 +35,8 @@ webdriver {
   chrome.silentOutput = true
 }
 
-# Remove headless switch to debug the tests
-chrome.switches = "--headless --lang=en,--no-sandbox;--disable-gpu;--no-default-browser-check;--no-first-run;--disable-default-apps;--disable-popup-blocking;--disable-translate;--disable-background-timer-throttling;--disable-renderer-backgrounding;--disable-device-discovery-notifications;--window-size=1440,900;"
+# Set headless mode to false to debug the tests
+headless.mode = true
+chrome.switches = "--lang=en;--no-sandbox;--disable-gpu;--no-default-browser-check;--no-first-run;--disable-default-apps;--disable-popup-blocking;--disable-translate;--disable-background-timer-throttling;--disable-renderer-backgrounding;--disable-device-discovery-notifications;--window-size=1440,900;"
 
 junit.retry.tests = true


### PR DESCRIPTION

Some acceptance tests are failing with chrome/chromedriver 98

When writing text into a text area, serenity clears the text first and then writes the data.
With chromedriver 98 the clear method actually writes some chars into the field and it breaks the pipeline script

Bumping the serenity version fixes the problem