### PR TITLE
Add default settings to Build Monitor Views

### DIFF
--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/HideBadges.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/HideBadges.java
@@ -4,24 +4,24 @@ import com.smartcodeltd.jenkinsci.plugins.build_monitor.user_interface.BuildMoni
 
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Task;
-import net.serenitybdd.screenplay.actions.CheckCheckbox;
+import net.serenitybdd.screenplay.actions.UncheckCheckbox;
 import net.serenitybdd.screenplay.waits.WaitUntil;
 import net.thucydides.core.annotations.Step;
 
 import static net.serenitybdd.screenplay.Tasks.instrumented;
 import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isVisible;
 
-public class ShowBadges implements Task {
+public class HideBadges implements Task {
     public static Task onTheDashboard() {
-        return instrumented(ShowBadges.class);
+        return instrumented(HideBadges.class);
     }
 
-    @Step("{0} decides to display the badges on the dashboard")
+    @Step("{0} decides to hide the badges on the dashboard")
     @Override
     public <T extends Actor> void performAs(T actor) {
         actor.attemptsTo(
             WaitUntil.the(BuildMonitorDashboard.Show_Badges, isVisible()),
-            CheckCheckbox.of(BuildMonitorDashboard.Show_Badges)
+            UncheckCheckbox.of(BuildMonitorDashboard.Show_Badges)
         );
     }
 }

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/configuration/ConfigureViewSettings.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/configuration/ConfigureViewSettings.java
@@ -1,0 +1,48 @@
+package com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.configuration;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Task;
+import net.serenitybdd.screenplay.actions.CheckCheckbox;
+import net.serenitybdd.screenplay.actions.Enter;
+import net.serenitybdd.screenplay.actions.UncheckCheckbox;
+import net.serenitybdd.screenplay.jenkins.user_interface.ViewConfigurationPage;
+import net.serenitybdd.screenplay.targets.Target;
+import net.serenitybdd.screenplayx.actions.Scroll;
+import net.thucydides.core.annotations.Step;
+
+import static net.serenitybdd.screenplay.Tasks.instrumented;
+
+public class ConfigureViewSettings implements Task {
+
+    public static Task showBadges() {
+        return instrumented(ConfigureViewSettings.class, ViewConfigurationPage.Enable_Show_Badges, true);
+    }
+
+    public static Task doNotShowBadges() {
+        return instrumented(ConfigureViewSettings.class, ViewConfigurationPage.Enable_Show_Badges, false);
+    }
+
+    @Step("{0} configures the view settings")
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        if (value instanceof Boolean) {
+            actor.attemptsTo(
+                    Scroll.to(target),
+                    ((Boolean) value).booleanValue() ? CheckCheckbox.of(target) : UncheckCheckbox.of(target)
+            );
+        } else {
+            actor.attemptsTo(
+                    Scroll.to(target),
+                    Enter.theValue(value.toString()).into(target)
+            );
+        }
+    }
+
+    public ConfigureViewSettings(Target target, Object value) {
+        this.target = target;
+        this.value = value;
+    }
+
+    private final Target target;
+    private final Object value;
+}

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/configuration/DisplayJunitRealtimeProgress.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/tasks/configuration/DisplayJunitRealtimeProgress.java
@@ -2,7 +2,7 @@ package com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.configuration;
 
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Task;
-import net.serenitybdd.screenplay.jenkins.actions.Choose;
+import net.serenitybdd.screenplay.actions.CheckCheckbox;
 import net.serenitybdd.screenplay.jenkins.user_interface.ViewConfigurationPage;
 import net.serenitybdd.screenplayx.actions.Scroll;
 import net.thucydides.core.annotations.Step;
@@ -19,7 +19,7 @@ public class DisplayJunitRealtimeProgress implements Task {
     public <T extends Actor> void performAs(T actor) {
         actor.attemptsTo(
             Scroll.to(ViewConfigurationPage.Display_JUnit_Realtime_Progress),
-            Choose.the(ViewConfigurationPage.Display_JUnit_Realtime_Progress)
+            CheckCheckbox.of(ViewConfigurationPage.Display_JUnit_Realtime_Progress)
         );
     }
 }

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/ViewConfigurationPage.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/screenplay/jenkins/user_interface/ViewConfigurationPage.java
@@ -10,6 +10,7 @@ public class ViewConfigurationPage {
     public static final Target Recurse_In_Subfolders            = Target.the("the 'Recurse in subfolders' option").locatedBy("#recurse");
     public static final Target Use_Regular_Expression           = Checkbox.withLabel("Use a regular expression to include jobs into the view");
     public static final Target Regular_Expression               = Target.the("the 'Regular expression' field").located(By.name("includeRegex"));
+    public static final Target Enable_Show_Badges               = Target.the("the 'Enable Show badges' option").locatedBy("#showBadges");
     public static final Target Display_Badges                   = Target.the("the 'Display badges' field").located(By.name("displayBadges"));
     public static final Target Display_Badges_From              = Target.the("the 'Display badges from' field").located(By.name("displayBadgesFrom"));
     public static final Target Display_JUnit_Realtime_Progress  = Target.the("the 'Display JUnit Realtime progress' option").locatedBy("#displayJUnitProgress");

--- a/build-monitor-acceptance/src/test/java/features/ShouldDisplayBadges.java
+++ b/build-monitor-acceptance/src/test/java/features/ShouldDisplayBadges.java
@@ -2,8 +2,10 @@ package features;
 
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.questions.ProjectWidget;
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.CreateABuildMonitorView;
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.HideBadges;
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.ModifyControlPanelOptions;
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.ShowBadges;
+import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.configuration.ConfigureViewSettings;
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.configuration.DisplayAllProjects;
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.configuration.DisplayBadges;
 import com.smartcodeltd.jenkinsci.plugins.build_monitor.tasks.configuration.DisplayBadgesFrom;
@@ -66,6 +68,7 @@ public class ShouldDisplayBadges extends BuilMonitorAcceptanceTest {
                 ScheduleABuild.of("My App"),
                 CreateABuildMonitorView.called("Build Monitor").andConfigureItTo(
                         DisplayAllProjects.usingARegularExpression(),
+                        ConfigureViewSettings.doNotShowBadges(),
                         DisplayBadges.asAUserSetting(),
                         DisplayBadgesFrom.theLastBuild()
                 )
@@ -85,14 +88,16 @@ public class ShouldDisplayBadges extends BuilMonitorAcceptanceTest {
                 HaveAPipelineProjectCreated.called("My App").andConfiguredTo(
                         SetPipelineDefinition.asFollows(Adds_A_Badge.code())
                 ),
-                ScheduleABuild.of("My App")
+                ScheduleABuild.of("My App"),
+                CreateABuildMonitorView.called("Build Monitor").andConfigureItTo(
+                        DisplayAllProjects.usingARegularExpression(),
+                        ConfigureViewSettings.showBadges(),
+                        DisplayBadges.always(),
+                        DisplayBadgesFrom.theLastBuild()
+                )
         );
 
-        when(paul).attemptsTo(CreateABuildMonitorView.called("Build Monitor").andConfigureItTo(
-                DisplayAllProjects.usingARegularExpression(),
-                DisplayBadges.always(),
-                DisplayBadgesFrom.theLastBuild()
-        ));
+        when(paul).attemptsTo(ModifyControlPanelOptions.to(HideBadges.onTheDashboard()));
 
         then(paul).should(seeThat(ProjectWidget.of("My App").badges(),
                 isCurrentlyVisible()
@@ -109,6 +114,7 @@ public class ShouldDisplayBadges extends BuilMonitorAcceptanceTest {
                 ScheduleABuild.of("My App"),
                 CreateABuildMonitorView.called("Build Monitor").andConfigureItTo(
                         DisplayAllProjects.usingARegularExpression(),
+                        ConfigureViewSettings.doNotShowBadges(),
                         DisplayBadges.never(),
                         DisplayBadgesFrom.theLastBuild()
                 )

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorDescriptor.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorDescriptor.java
@@ -53,4 +53,34 @@ public final class BuildMonitorDescriptor extends ViewDescriptor {
     public void setPermissionToCollectAnonymousUsageStatistics(boolean collect) {
         this.permissionToCollectAnonymousUsageStatistics = collect;
     }
+
+    public FormValidation doCheckMaxColumns(@QueryParameter String value) {
+        try {
+            int intValue = Integer.parseInt(value);
+            if(intValue > 0) {
+                return FormValidation.ok();
+            } else {
+                return FormValidation.error("Must be an integer, greater than 0.");
+            }
+        } catch (NullPointerException npe) {
+            return FormValidation.error("Cannot be null.");
+        } catch (NumberFormatException nfe) {
+            return FormValidation.error("Must be an integer.");
+        }
+    }
+
+    public FormValidation doCheckTextScale(@QueryParameter String value) {
+        try {
+            double doubleValue = Double.parseDouble(value);
+            if(doubleValue > 0.0) {
+                return FormValidation.ok();
+            } else {
+                return FormValidation.error("Must be a double, greater than 0.0.");
+            }
+        } catch (NullPointerException npe) {
+            return FormValidation.error("Cannot be null.");
+        } catch (NumberFormatException nfe) {
+            return FormValidation.error("Must be a double.");
+        }
+    }
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView.java
@@ -96,6 +96,36 @@ public class BuildMonitorView extends ListView {
         return currentConfig().shouldDisplayCommitters();
     }
 
+    // used in the configure-entries.jelly and main-settings.jelly forms
+    @SuppressWarnings("unused")
+    public double getTextScale() {
+        return currentConfig().getTextScale();
+    }
+
+    // used in the configure-entries.jelly and main-settings.jelly forms
+    @SuppressWarnings("unused")
+    public int getMaxColumns() {
+        return currentConfig().getMaxColumns();
+    }
+
+    // used in the configure-entries.jelly and main-settings.jelly forms
+    @SuppressWarnings("unused")
+    public boolean isColourBlindMode() {
+        return currentConfig().colourBlindMode();
+    }
+
+    // used in the configure-entries.jelly and main-settings.jelly forms
+    @SuppressWarnings("unused")
+    public boolean isReduceMotion() {
+        return currentConfig().reduceMotion();
+    }
+
+    // used in the configure-entries.jelly and main-settings.jelly forms
+    @SuppressWarnings("unused")
+    public boolean isShowBadges() {
+        return currentConfig().showBadges();
+    }
+
     @SuppressWarnings("unused") // used in the configure-entries.jelly form
     public String currentDisplayBadges() {
         return currentConfig().getDisplayBadges().name();
@@ -138,7 +168,12 @@ public class BuildMonitorView extends ListView {
             String requestedOrdering = req.getParameter("order");
             String displayBadgesFrom = req.getParameter("displayBadgesFrom");
             title                    = req.getParameter("title");
+            String maxColumns        = req.getParameter("maxColumns");
+            String textScale         = req.getParameter("textScale");
 
+            currentConfig().setColourBlindMode(json.optBoolean("colourBlindMode", false));
+            currentConfig().setReduceMotion(json.optBoolean("reduceMotion", false));
+            currentConfig().setShowBadges(json.optBoolean("showBadges", true));
             currentConfig().setDisplayBadges(req.getParameter("displayBadges"));
             currentConfig().setDisplayCommitters(json.optBoolean("displayCommitters", true));
             currentConfig().setBuildFailureAnalyzerDisplayedField(req.getParameter("buildFailureAnalyzerDisplayedField"));
@@ -148,6 +183,18 @@ public class BuildMonitorView extends ListView {
                 currentConfig().setOrder(orderIn(requestedOrdering));
             } catch (Exception e) {
                 throw new FormException("Can't order projects by " + requestedOrdering, "order");
+            }
+
+            try {
+                currentConfig().setMaxColumns(Integer.parseInt(maxColumns));
+            } catch (Exception e) {
+                throw new FormException("Invalid value of 'Maximum number of columns': '" + maxColumns + "' (should be double).", maxColumns);
+            }
+
+            try {
+                currentConfig().setTextScale(Double.parseDouble(textScale));
+            } catch (Exception e) {
+                throw new FormException("Invalid value of 'Text scale': '" + textScale + "' (should be double).", textScale);
             }
 
             try {
@@ -178,13 +225,13 @@ public class BuildMonitorView extends ListView {
         JobViews views = new JobViews(new StaticJenkinsAPIs(), currentConfig());
 
         //A little bit of evil to make the type system happy.
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({ "unchecked", "rawtypes" })
         List<Job<?, ?>> projects = new ArrayList(filter(super.getItems(), Job.class));
         List<JobView> jobs = new ArrayList<>();
 
         projects.sort(currentConfig().getOrder());
 
-        for (Job project : projects) {
+        for (Job<?, ?> project : projects) {
             jobs.add(views.viewOf(project));
         }
 

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/Config.java
@@ -10,11 +10,16 @@ import java.util.Optional;
 
 public class Config {
 
-    private boolean displayCommitters;
+    private Boolean colourBlindMode;
+    private Boolean displayCommitters;
+    private Boolean reduceMotion;
+    private Integer maxColumns;
+    private Double textScale;
+    private Boolean showBadges;
     private DisplayOptions displayBadges;
     private GetBuildViewModel displayBadgesFrom;
     private BuildFailureAnalyzerDisplayedField buildFailureAnalyzerDisplayedField;
-    private boolean displayJUnitProgress;
+    private Boolean displayJUnitProgress;
     
     public static Config defaultConfig() {
         return new Config();
@@ -43,6 +48,14 @@ public class Config {
     public void setBuildFailureAnalyzerDisplayedField(String buildFailureAnalyzerDisplayedField) {
         this.buildFailureAnalyzerDisplayedField = BuildFailureAnalyzerDisplayedField.valueOf(buildFailureAnalyzerDisplayedField);
     }
+
+    public boolean colourBlindMode() {
+        return Optional.ofNullable(colourBlindMode).orElse(false);
+    }
+
+    public void setColourBlindMode(boolean flag) {
+        this.colourBlindMode = flag;
+    }
     
     public boolean shouldDisplayCommitters() {
         return Optional.ofNullable(displayCommitters).orElse(true);
@@ -50,6 +63,22 @@ public class Config {
 
     public void setDisplayCommitters(boolean flag) {
         this.displayCommitters = flag;
+    }
+
+    public boolean reduceMotion() {
+        return Optional.ofNullable(reduceMotion).orElse(false);
+    }
+
+    public void setReduceMotion(boolean flag) {
+        this.reduceMotion = flag;
+    }
+
+    public boolean showBadges() {
+        return Optional.ofNullable(showBadges).orElse(true);
+    }
+
+    public void setShowBadges(boolean flag) {
+        this.showBadges = flag;
     }
     
     public DisplayOptions getDisplayBadges() {
@@ -69,11 +98,27 @@ public class Config {
     }
 
     public boolean shouldDisplayJUnitProgress() {
-        return Optional.of(displayJUnitProgress).orElse(true);
+        return Optional.ofNullable(displayJUnitProgress).orElse(true);
     }
 
     public void setDisplayJUnitProgress(boolean flag) {
         this.displayJUnitProgress = flag;
+    }
+
+    public int getMaxColumns() {
+        return Optional.ofNullable(maxColumns).orElse(2);
+    }
+
+    public void setMaxColumns(int maxColumns) {
+        this.maxColumns = maxColumns;
+    }
+
+    public double getTextScale() {
+        return Optional.ofNullable(textScale).orElse(1.0);
+    }
+
+    public void setTextScale(double scale) {
+        this.textScale = scale;
     }
 
     @Override

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/configure-entries.jelly
@@ -70,6 +70,30 @@
 
   </f:section>
 
+  <f:section title="${%Build Monitor - Default Display Settings}">
+
+    <f:entry title="${%Text scale}" field="textScale">
+      <f:textbox name="textScale" value="${it.textScale}" />
+    </f:entry>
+
+    <f:entry title="${%Maximum number of columns}" field="maxColumns">
+      <f:textbox name="maxColumns" value="${it.maxColumns}" />
+    </f:entry>
+
+    <f:entry title="${%Enable Colour blind mode}">
+      <f:checkbox id="colourBlindMode" field="colourBlindMode" />
+    </f:entry>
+
+    <f:entry title="${%Enable Reduce motion}">
+      <f:checkbox id="reduceMotion" field="reduceMotion" />
+    </f:entry>
+
+    <f:entry title="${%Enable Show badges}">
+      <f:checkbox id="showBadges" field="showBadges" />
+    </f:entry>
+
+  </f:section>
+
   <f:section title="${%Build Monitor - Widget Settings}">
 
     <f:entry title="${%Display committers}" help="${descriptor.getHelpFile('displayCommitters')}">

--- a/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
+++ b/build-monitor-plugin/src/main/resources/com/smartcodeltd/jenkinsci/plugins/buildmonitor/BuildMonitorView/main-settings.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-    <nav data-ng-controller="controlPanel" data-ng-init="built_at = '${it.installation.buildMonitorBuiltAt()}'">
+    <nav data-ng-controller="controlPanel" data-ng-init="built_at = '${it.installation.buildMonitorBuiltAt()}'; defaults.fontSize = ${it.textScale}; defaults.numberOfColumns = ${it.maxColumns}; defaults.colourBlind = ${it.colourBlindMode}; defaults.reduceMotion = ${it.reduceMotion}; defaults.showBadges = ${it.showBadges}; addCookie()">
         <span data-ng-show="newVersionAvailable" class="notifications">!</span>
         <section data-ng-class="{ showSettings:toggleSettings }">
             <input id="settings-toggle" type="checkbox" class="settings" data-ng-model="toggleSettings" />
@@ -15,11 +15,11 @@
                 </li>
                 <li class="settings-option">
                     <span class="slider-label">Text scale</span>
-                    <rzslider rz-slider-model="settings.fontSize" rz-slider-options="{ floor: 0.1, ceil: 2, step: 0.1, precision: 1 }"></rzslider>
+                    <rzslider rz-slider-model="settings.fontSize" rz-slider-options="{ floor: 0.1, ceil: 5, step: 0.1, precision: 1 }"></rzslider>
                 </li>
                 <li class="settings-option">
                     <span class="slider-label">Maximum number of columns</span>
-                    <rzslider rz-slider-model="settings.numberOfColumns" rz-slider-options="{ floor: 1, ceil: 8, step: 1, precision: 0 }"></rzslider>
+                    <rzslider rz-slider-model="settings.numberOfColumns" rz-slider-options="{ floor: 1, ceil: 20, step: 1, precision: 0 }"></rzslider>
                 </li>
                 <li class="settings-option">
                     <input ng-model="settings.colourBlind"
@@ -41,6 +41,11 @@
                            ng-true-value="'1'"
                            id="settings-show-badges" type="checkbox" />
                     <label for="settings-show-badges" title="Show the last build badges">Show badges?</label>
+                </li>
+                <li class="buttons">
+                    <a class="btn"
+                       data-ng-click="resetSettings()"
+                       title="Reset to defaults.">Reset to defaults</a>
                 </li>
                 <li class="buttons">
                     <a class="btn"

--- a/build-monitor-plugin/src/main/webapp/scripts/settings.js
+++ b/build-monitor-plugin/src/main/webapp/scripts/settings.js
@@ -5,20 +5,38 @@ angular.
         function ($scope, cookieJar, townCrier) {
             'use strict';
 
-            $scope.settings.fontSize        = cookieJar.get('fontSize',        1);
-            $scope.settings.numberOfColumns = cookieJar.get('numberOfColumns', 2);
-            $scope.settings.colourBlind     = cookieJar.get('colourBlind',     0);
-            $scope.settings.reduceMotion    = cookieJar.get('reduceMotion',    0);
-            $scope.settings.showBadges      = cookieJar.get('showBadges',      0);
-
-            angular.forEach($scope.settings, function(value, name) {
-                $scope.$watch('settings.' + name, function(currentValue) {
-                    cookieJar.put(name, currentValue);
+            $scope.updateCookie = function() {
+                angular.forEach($scope.settings, function(value, name) {
+                    $scope.$watch('settings.' + name, function(currentValue) {
+                        cookieJar.put(name, currentValue);
+                    });
                 });
-            });
+            }
 
-            // that's the minimum viable product .. at its tiniest
-            townCrier.uponNewVersion(function() {
-                $scope.newVersionAvailable = true;
-            });
+            $scope.addCookie = function() {
+                $scope.defaults.colourBlind     = $scope.defaults.colourBlind ? "1" : "0"
+                $scope.defaults.reduceMotion    = $scope.defaults.reduceMotion ? "1" : "0"
+                $scope.defaults.showBadges      = $scope.defaults.showBadges ? "1" : "0"
+
+                $scope.settings.fontSize        = cookieJar.get('fontSize',        $scope.defaults.fontSize);
+                $scope.settings.numberOfColumns = cookieJar.get('numberOfColumns', $scope.defaults.numberOfColumns);
+                $scope.settings.colourBlind     = cookieJar.get('colourBlind',     $scope.defaults.colourBlind);
+                $scope.settings.reduceMotion    = cookieJar.get('reduceMotion',    $scope.defaults.reduceMotion);
+                $scope.settings.showBadges      = cookieJar.get('showBadges',      $scope.defaults.showBadges);
+
+                $scope.updateCookie();
+
+                // that's the minimum viable product .. at its tiniest
+                townCrier.uponNewVersion(function() {
+                    $scope.newVersionAvailable = true;
+                });
+            }
+
+            $scope.resetSettings = function() {
+                angular.forEach($scope.defaults, function(value, name) {
+                    $scope.settings[name] = value;
+                });
+
+                $scope.updateCookie();
+            }
         }]);


### PR DESCRIPTION
This is a "rebase" of #425

Now using the view config page, any positive value can be set for font size and number of columns. (Which is a good thing as poeple did not always like the current limitations, who are we to say what looks better on their monitor).

To reflect that, I have also increased the sliders in the Settings panel, font size 0.1 to 5 (was 2), number of columns 1 to 20 (was 8). These are still arbitrary values but I did not want to change the slider so I had to set something that seems reasonable.

After this is merged we can close the following PRs and issues: 

Fixes #425 
Fixes #413
Fixes #409 
Fixes #315 
Fixes #227
Fixes #189
Fixes #119
Fixes #71